### PR TITLE
Migrate Slick models to JPA entities

### DIFF
--- a/TARGET/src/main/java/realworld/com/model/Article.java
+++ b/TARGET/src/main/java/realworld/com/model/Article.java
@@ -1,0 +1,165 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "articles")
+public class Article {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false, unique = true)
+    private String slug;
+    
+    @Column(nullable = false, length = 300)
+    private String title;
+    
+    @Column(nullable = false)
+    private String description;
+    
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String body;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+    
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+    
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+    
+    @ManyToMany
+    @JoinTable(
+        name = "articles_tags",
+        joinColumns = @JoinColumn(name = "article_id"),
+        inverseJoinColumns = @JoinColumn(name = "tag_id"),
+        uniqueConstraints = @UniqueConstraint(name = "article_tag_id_unique", columnNames = {"article_id", "tag_id"})
+    )
+    private Set<Tag> tags = new HashSet<>();
+    
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Comment> comments = new HashSet<>();
+    
+    @OneToMany(mappedBy = "favorited", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Favorite> favorites = new HashSet<>();
+    
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+    // Getters and Setters
+    
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getSlug() {
+        return slug;
+    }
+    
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+    
+    public String getTitle() {
+        return title;
+    }
+    
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
+    public String getBody() {
+        return body;
+    }
+    
+    public void setBody(String body) {
+        this.body = body;
+    }
+    
+    public User getAuthor() {
+        return author;
+    }
+    
+    public void setAuthor(User author) {
+        this.author = author;
+    }
+    
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+    
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+    
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+    
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+    
+    public Set<Tag> getTags() {
+        return tags;
+    }
+    
+    public void setTags(Set<Tag> tags) {
+        this.tags = tags;
+    }
+    
+    public Set<Comment> getComments() {
+        return comments;
+    }
+    
+    public void setComments(Set<Comment> comments) {
+        this.comments = comments;
+    }
+    
+    public Set<Favorite> getFavorites() {
+        return favorites;
+    }
+    
+    public void setFavorites(Set<Favorite> favorites) {
+        this.favorites = favorites;
+    }
+    
+    public int getFavoritesCount() {
+        return favorites.size();
+    }
+    
+    public void addTag(Tag tag) {
+        tags.add(tag);
+    }
+    
+    public void removeTag(Tag tag) {
+        tags.remove(tag);
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/ArticleTag.java
+++ b/TARGET/src/main/java/realworld/com/model/ArticleTag.java
@@ -1,0 +1,79 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+
+/**
+ * This entity represents the join table between Article and Tag.
+ * While JPA can handle many-to-many relationships automatically,
+ * this entity is provided for compatibility with the existing schema
+ * that has an id column in the join table.
+ */
+@Entity
+@Table(name = "articles_tags")
+public class ArticleTag {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+    
+    @ManyToOne
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+    
+    // Constructors
+    public ArticleTag() {
+    }
+    
+    public ArticleTag(Article article, Tag tag) {
+        this.article = article;
+        this.tag = tag;
+    }
+    
+    // Getters and Setters
+    
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public Article getArticle() {
+        return article;
+    }
+    
+    public void setArticle(Article article) {
+        this.article = article;
+    }
+    
+    public Tag getTag() {
+        return tag;
+    }
+    
+    public void setTag(Tag tag) {
+        this.tag = tag;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ArticleTag)) return false;
+        
+        ArticleTag that = (ArticleTag) o;
+        
+        if (article != null ? !article.equals(that.article) : that.article != null) return false;
+        return tag != null ? tag.equals(that.tag) : that.tag == null;
+    }
+    
+    @Override
+    public int hashCode() {
+        int result = article != null ? article.hashCode() : 0;
+        result = 31 * result + (tag != null ? tag.hashCode() : 0);
+        return result;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Comment.java
+++ b/TARGET/src/main/java/realworld/com/model/Comment.java
@@ -1,0 +1,91 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comments")
+public class Comment {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false, length = 4096)
+    private String body;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+    
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+    
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+    
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+    // Getters and Setters
+    
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getBody() {
+        return body;
+    }
+    
+    public void setBody(String body) {
+        this.body = body;
+    }
+    
+    public Article getArticle() {
+        return article;
+    }
+    
+    public void setArticle(Article article) {
+        this.article = article;
+    }
+    
+    public User getAuthor() {
+        return author;
+    }
+    
+    public void setAuthor(User author) {
+        this.author = author;
+    }
+    
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+    
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+    
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+    
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Favorite.java
+++ b/TARGET/src/main/java/realworld/com/model/Favorite.java
@@ -1,0 +1,73 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "favorite")
+public class Favorite {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "favorited_id", nullable = false)
+    private Article favorited;
+    
+    // Constructors
+    public Favorite() {
+    }
+    
+    public Favorite(User user, Article favorited) {
+        this.user = user;
+        this.favorited = favorited;
+    }
+    
+    // Getters and Setters
+    
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public User getUser() {
+        return user;
+    }
+    
+    public void setUser(User user) {
+        this.user = user;
+    }
+    
+    public Article getFavorited() {
+        return favorited;
+    }
+    
+    public void setFavorited(Article favorited) {
+        this.favorited = favorited;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Favorite)) return false;
+        
+        Favorite favorite = (Favorite) o;
+        
+        if (user != null ? !user.equals(favorite.user) : favorite.user != null) return false;
+        return favorited != null ? favorited.equals(favorite.favorited) : favorite.favorited == null;
+    }
+    
+    @Override
+    public int hashCode() {
+        int result = user != null ? user.hashCode() : 0;
+        result = 31 * result + (favorited != null ? favorited.hashCode() : 0);
+        return result;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Tag.java
+++ b/TARGET/src/main/java/realworld/com/model/Tag.java
@@ -1,0 +1,69 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "tags")
+public class Tag {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false, unique = true)
+    private String name;
+    
+    @ManyToMany(mappedBy = "tags")
+    private Set<Article> articles = new HashSet<>();
+    
+    // Constructors
+    public Tag() {
+    }
+    
+    public Tag(String name) {
+        this.name = name;
+    }
+    
+    // Getters and Setters
+    
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public Set<Article> getArticles() {
+        return articles;
+    }
+    
+    public void setArticles(Set<Article> articles) {
+        this.articles = articles;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Tag)) return false;
+        
+        Tag tag = (Tag) o;
+        
+        return name != null ? name.equals(tag.name) : tag.name == null;
+    }
+    
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 0;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/User.java
+++ b/TARGET/src/main/java/realworld/com/model/User.java
@@ -1,0 +1,175 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "users", uniqueConstraints = {
+    @UniqueConstraint(name = "user_email_unique", columnNames = "email"),
+    @UniqueConstraint(name = "user_username_unique", columnNames = "username")
+})
+public class User {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false)
+    private String username;
+    
+    @Column(nullable = false)
+    private String password;
+    
+    @Column(nullable = false)
+    private String email;
+    
+    @Column(length = 1024)
+    private String bio;
+    
+    private String image;
+    
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+    
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+    
+    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL)
+    private Set<Article> articles = new HashSet<>();
+    
+    @OneToMany(mappedBy = "author", cascade = CascadeType.ALL)
+    private Set<Comment> comments = new HashSet<>();
+    
+    @ManyToMany
+    @JoinTable(
+        name = "followers",
+        joinColumns = @JoinColumn(name = "user_id"),
+        inverseJoinColumns = @JoinColumn(name = "followee_id")
+    )
+    private Set<User> following = new HashSet<>();
+    
+    @ManyToMany(mappedBy = "following")
+    private Set<User> followers = new HashSet<>();
+    
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private Set<Favorite> favorites = new HashSet<>();
+    
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+    // Getters and Setters
+    
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getUsername() {
+        return username;
+    }
+    
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    
+    public String getPassword() {
+        return password;
+    }
+    
+    public void setPassword(String password) {
+        this.password = password;
+    }
+    
+    public String getEmail() {
+        return email;
+    }
+    
+    public void setEmail(String email) {
+        this.email = email;
+    }
+    
+    public String getBio() {
+        return bio;
+    }
+    
+    public void setBio(String bio) {
+        this.bio = bio;
+    }
+    
+    public String getImage() {
+        return image;
+    }
+    
+    public void setImage(String image) {
+        this.image = image;
+    }
+    
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+    
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+    
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+    
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+    
+    public Set<Article> getArticles() {
+        return articles;
+    }
+    
+    public void setArticles(Set<Article> articles) {
+        this.articles = articles;
+    }
+    
+    public Set<Comment> getComments() {
+        return comments;
+    }
+    
+    public void setComments(Set<Comment> comments) {
+        this.comments = comments;
+    }
+    
+    public Set<User> getFollowing() {
+        return following;
+    }
+    
+    public void setFollowing(Set<User> following) {
+        this.following = following;
+    }
+    
+    public Set<User> getFollowers() {
+        return followers;
+    }
+    
+    public void setFollowers(Set<User> followers) {
+        this.followers = followers;
+    }
+    
+    public Set<Favorite> getFavorites() {
+        return favorites;
+    }
+    
+    public void setFavorites(Set<Favorite> favorites) {
+        this.favorites = favorites;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/UserFollower.java
+++ b/TARGET/src/main/java/realworld/com/model/UserFollower.java
@@ -1,0 +1,81 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * This class represents a composite entity for the followers table.
+ * In JPA, we typically handle many-to-many relationships directly with @ManyToMany,
+ * but this entity is provided for compatibility with the existing schema that has
+ * an inserted_at timestamp column.
+ */
+@Entity
+@Table(name = "followers")
+public class UserFollower {
+    
+    @EmbeddedId
+    private UserFollowerId id;
+    
+    @ManyToOne
+    @MapsId("userId")
+    @JoinColumn(name = "user_id")
+    private User user;
+    
+    @ManyToOne
+    @MapsId("followeeId")
+    @JoinColumn(name = "followee_id")
+    private User followee;
+    
+    @Column(name = "inserted_at", nullable = false)
+    private LocalDateTime insertedAt;
+    
+    @PrePersist
+    protected void onCreate() {
+        this.insertedAt = LocalDateTime.now();
+    }
+    
+    // Constructors
+    public UserFollower() {
+    }
+    
+    public UserFollower(User user, User followee) {
+        this.user = user;
+        this.followee = followee;
+        this.id = new UserFollowerId(user.getId(), followee.getId());
+        this.insertedAt = LocalDateTime.now();
+    }
+    
+    // Getters and Setters
+    
+    public UserFollowerId getId() {
+        return id;
+    }
+    
+    public void setId(UserFollowerId id) {
+        this.id = id;
+    }
+    
+    public User getUser() {
+        return user;
+    }
+    
+    public void setUser(User user) {
+        this.user = user;
+    }
+    
+    public User getFollowee() {
+        return followee;
+    }
+    
+    public void setFollowee(User followee) {
+        this.followee = followee;
+    }
+    
+    public LocalDateTime getInsertedAt() {
+        return insertedAt;
+    }
+    
+    public void setInsertedAt(LocalDateTime insertedAt) {
+        this.insertedAt = insertedAt;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/UserFollowerId.java
+++ b/TARGET/src/main/java/realworld/com/model/UserFollowerId.java
@@ -1,0 +1,60 @@
+package realworld.com.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Composite primary key for the UserFollower entity
+ */
+@Embeddable
+public class UserFollowerId implements Serializable {
+    
+    @Column(name = "user_id")
+    private Long userId;
+    
+    @Column(name = "followee_id")
+    private Long followeeId;
+    
+    // Constructors
+    public UserFollowerId() {
+    }
+    
+    public UserFollowerId(Long userId, Long followeeId) {
+        this.userId = userId;
+        this.followeeId = followeeId;
+    }
+    
+    // Getters and Setters
+    
+    public Long getUserId() {
+        return userId;
+    }
+    
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+    
+    public Long getFolloweeId() {
+        return followeeId;
+    }
+    
+    public void setFolloweeId(Long followeeId) {
+        this.followeeId = followeeId;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserFollowerId that = (UserFollowerId) o;
+        return Objects.equals(userId, that.userId) &&
+               Objects.equals(followeeId, that.followeeId);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, followeeId);
+    }
+}


### PR DESCRIPTION
This PR migrates the Slick models to JPA entities.

Changes:
- Created JPA entity classes for all models in the application
- Used proper JPA annotations for entity relationships
- Converted Scala case classes to Java classes with proper getters and setters
- Added appropriate JPA lifecycle callbacks for timestamp fields
- Implemented proper equals and hashCode methods where needed
- Used composite key for the followers relationship

All entities are placed in the TARGET/src/main/java/realworld/com/model directory.