### PR TITLE
Migrate Slick models to JPA entities

### DIFF
--- a/TARGET/pom.xml
+++ b/TARGET/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>realworld.com</groupId>
+    <artifactId>spring-boot-realworld-example</artifactId>
+    <version>0.1.0</version>
+    <name>spring-boot-realworld-example</name>
+    <description>Spring Boot implementation of RealWorld example</description>
+    
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.flywaydb</groupId>
+                <artifactId>flyway-maven-plugin</artifactId>
+                <configuration>
+                    <locations>
+                        <location>classpath:db/migration</location>
+                    </locations>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/TARGET/src/main/java/realworld/com/RealWorldApplication.java
+++ b/TARGET/src/main/java/realworld/com/RealWorldApplication.java
@@ -1,0 +1,14 @@
+package realworld.com;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@SpringBootApplication
+@EnableJpaAuditing
+public class RealWorldApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(RealWorldApplication.class, args);
+    }
+}

--- a/TARGET/src/main/java/realworld/com/dto/ArticleDto.java
+++ b/TARGET/src/main/java/realworld/com/dto/ArticleDto.java
@@ -1,0 +1,100 @@
+package realworld.com.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class ArticleDto {
+    private String slug;
+    private String title;
+    private String description;
+    private String body;
+    private List<String> tagList;
+    private String createdAt;
+    private String updatedAt;
+    private boolean favorited;
+    private int favoritesCount;
+    private ProfileDto author;
+    
+    public ArticleDto() {
+    }
+    
+    public String getSlug() {
+        return slug;
+    }
+    
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+    
+    public String getTitle() {
+        return title;
+    }
+    
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
+    public String getBody() {
+        return body;
+    }
+    
+    public void setBody(String body) {
+        this.body = body;
+    }
+    
+    public List<String> getTagList() {
+        return tagList;
+    }
+    
+    public void setTagList(List<String> tagList) {
+        this.tagList = tagList;
+    }
+    
+    public String getCreatedAt() {
+        return createdAt;
+    }
+    
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+    
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+    
+    public void setUpdatedAt(String updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+    
+    public boolean isFavorited() {
+        return favorited;
+    }
+    
+    public void setFavorited(boolean favorited) {
+        this.favorited = favorited;
+    }
+    
+    public int getFavoritesCount() {
+        return favoritesCount;
+    }
+    
+    public void setFavoritesCount(int favoritesCount) {
+        this.favoritesCount = favoritesCount;
+    }
+    
+    public ProfileDto getAuthor() {
+        return author;
+    }
+    
+    public void setAuthor(ProfileDto author) {
+        this.author = author;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/dto/CommentDto.java
+++ b/TARGET/src/main/java/realworld/com/dto/CommentDto.java
@@ -1,0 +1,52 @@
+package realworld.com.dto;
+
+public class CommentDto {
+    private Long id;
+    private String body;
+    private String createdAt;
+    private String updatedAt;
+    private ProfileDto author;
+    
+    public CommentDto() {
+    }
+    
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getBody() {
+        return body;
+    }
+    
+    public void setBody(String body) {
+        this.body = body;
+    }
+    
+    public String getCreatedAt() {
+        return createdAt;
+    }
+    
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+    
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+    
+    public void setUpdatedAt(String updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+    
+    public ProfileDto getAuthor() {
+        return author;
+    }
+    
+    public void setAuthor(ProfileDto author) {
+        this.author = author;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/dto/ProfileDto.java
+++ b/TARGET/src/main/java/realworld/com/dto/ProfileDto.java
@@ -1,0 +1,50 @@
+package realworld.com.dto;
+
+public class ProfileDto {
+    private String username;
+    private String bio;
+    private String image;
+    private boolean following;
+    
+    public ProfileDto() {
+    }
+    
+    public ProfileDto(String username, String bio, String image, boolean following) {
+        this.username = username;
+        this.bio = bio;
+        this.image = image;
+        this.following = following;
+    }
+    
+    public String getUsername() {
+        return username;
+    }
+    
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    
+    public String getBio() {
+        return bio;
+    }
+    
+    public void setBio(String bio) {
+        this.bio = bio;
+    }
+    
+    public String getImage() {
+        return image;
+    }
+    
+    public void setImage(String image) {
+        this.image = image;
+    }
+    
+    public boolean isFollowing() {
+        return following;
+    }
+    
+    public void setFollowing(boolean following) {
+        this.following = following;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/dto/TagDto.java
+++ b/TARGET/src/main/java/realworld/com/dto/TagDto.java
@@ -1,0 +1,20 @@
+package realworld.com.dto;
+
+public class TagDto {
+    private String name;
+    
+    public TagDto() {
+    }
+    
+    public TagDto(String name) {
+        this.name = name;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/dto/UserDto.java
+++ b/TARGET/src/main/java/realworld/com/dto/UserDto.java
@@ -1,0 +1,60 @@
+package realworld.com.dto;
+
+public class UserDto {
+    private String username;
+    private String email;
+    private String bio;
+    private String image;
+    private String token;
+    
+    public UserDto() {
+    }
+    
+    public UserDto(String username, String email, String bio, String image, String token) {
+        this.username = username;
+        this.email = email;
+        this.bio = bio;
+        this.image = image;
+        this.token = token;
+    }
+    
+    public String getUsername() {
+        return username;
+    }
+    
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    
+    public String getEmail() {
+        return email;
+    }
+    
+    public void setEmail(String email) {
+        this.email = email;
+    }
+    
+    public String getBio() {
+        return bio;
+    }
+    
+    public void setBio(String bio) {
+        this.bio = bio;
+    }
+    
+    public String getImage() {
+        return image;
+    }
+    
+    public void setImage(String image) {
+        this.image = image;
+    }
+    
+    public String getToken() {
+        return token;
+    }
+    
+    public void setToken(String token) {
+        this.token = token;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Article.java
+++ b/TARGET/src/main/java/realworld/com/model/Article.java
@@ -1,0 +1,178 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "articles")
+public class Article {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false, unique = true)
+    private String slug;
+    
+    @Column(nullable = false)
+    private String title;
+    
+    @Column(nullable = false)
+    private String description;
+    
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String body;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+    
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+    
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+    
+    @ManyToMany
+    @JoinTable(
+        name = "articles_tags",
+        joinColumns = @JoinColumn(name = "article_id"),
+        inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private Set<Tag> tags = new HashSet<>();
+    
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Comment> comments = new HashSet<>();
+    
+    @ManyToMany(mappedBy = "favoriteArticles")
+    private Set<User> favoritedBy = new HashSet<>();
+    
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+    // Getters and Setters
+    
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getSlug() {
+        return slug;
+    }
+    
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+    
+    public String getTitle() {
+        return title;
+    }
+    
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
+    public String getBody() {
+        return body;
+    }
+    
+    public void setBody(String body) {
+        this.body = body;
+    }
+    
+    public User getAuthor() {
+        return author;
+    }
+    
+    public void setAuthor(User author) {
+        this.author = author;
+    }
+    
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+    
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+    
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+    
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+    
+    public Set<Tag> getTags() {
+        return tags;
+    }
+    
+    public void setTags(Set<Tag> tags) {
+        this.tags = tags;
+    }
+    
+    public void addTag(Tag tag) {
+        this.tags.add(tag);
+    }
+    
+    public void removeTag(Tag tag) {
+        this.tags.remove(tag);
+    }
+    
+    public Set<Comment> getComments() {
+        return comments;
+    }
+    
+    public void setComments(Set<Comment> comments) {
+        this.comments = comments;
+    }
+    
+    public void addComment(Comment comment) {
+        comments.add(comment);
+        comment.setArticle(this);
+    }
+    
+    public void removeComment(Comment comment) {
+        comments.remove(comment);
+        comment.setArticle(null);
+    }
+    
+    public Set<User> getFavoritedBy() {
+        return favoritedBy;
+    }
+    
+    public void setFavoritedBy(Set<User> favoritedBy) {
+        this.favoritedBy = favoritedBy;
+    }
+    
+    public int getFavoritesCount() {
+        return this.favoritedBy.size();
+    }
+    
+    public static String slugify(String title) {
+        return title.toLowerCase().replaceAll("\\s", "-");
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Comment.java
+++ b/TARGET/src/main/java/realworld/com/model/Comment.java
@@ -1,0 +1,91 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comments")
+public class Comment {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false, length = 4096)
+    private String body;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+    
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+    
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+    
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+    // Getters and Setters
+    
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getBody() {
+        return body;
+    }
+    
+    public void setBody(String body) {
+        this.body = body;
+    }
+    
+    public Article getArticle() {
+        return article;
+    }
+    
+    public void setArticle(Article article) {
+        this.article = article;
+    }
+    
+    public User getAuthor() {
+        return author;
+    }
+    
+    public void setAuthor(User author) {
+        this.author = author;
+    }
+    
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+    
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+    
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+    
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Tag.java
+++ b/TARGET/src/main/java/realworld/com/model/Tag.java
@@ -1,0 +1,72 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "tags")
+public class Tag {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false, unique = true)
+    private String name;
+    
+    @ManyToMany(mappedBy = "tags")
+    private Set<Article> articles = new HashSet<>();
+    
+    // Constructors
+    
+    public Tag() {
+    }
+    
+    public Tag(String name) {
+        this.name = name;
+    }
+    
+    // Getters and Setters
+    
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public Set<Article> getArticles() {
+        return articles;
+    }
+    
+    public void setArticles(Set<Article> articles) {
+        this.articles = articles;
+    }
+    
+    // Equals and HashCode
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        
+        Tag tag = (Tag) o;
+        
+        return name != null ? name.equals(tag.name) : tag.name == null;
+    }
+    
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 0;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/User.java
+++ b/TARGET/src/main/java/realworld/com/model/User.java
@@ -1,0 +1,205 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+public class User {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false, unique = true)
+    private String username;
+    
+    @Column(nullable = false)
+    private String password;
+    
+    @Column(nullable = false, unique = true)
+    private String email;
+    
+    @Column(length = 1024)
+    private String bio;
+    
+    private String image;
+    
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+    
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+    
+    @OneToMany(mappedBy = "author")
+    private Set<Article> articles = new HashSet<>();
+    
+    @OneToMany(mappedBy = "author")
+    private Set<Comment> comments = new HashSet<>();
+    
+    @ManyToMany
+    @JoinTable(
+        name = "followers",
+        joinColumns = @JoinColumn(name = "user_id"),
+        inverseJoinColumns = @JoinColumn(name = "followee_id")
+    )
+    private Set<User> following = new HashSet<>();
+    
+    @ManyToMany(mappedBy = "following")
+    private Set<User> followers = new HashSet<>();
+    
+    @ManyToMany
+    @JoinTable(
+        name = "favorite",
+        joinColumns = @JoinColumn(name = "user_id"),
+        inverseJoinColumns = @JoinColumn(name = "favorited_id")
+    )
+    private Set<Article> favoriteArticles = new HashSet<>();
+    
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+    
+    // Getters and Setters
+    
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getUsername() {
+        return username;
+    }
+    
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    
+    public String getPassword() {
+        return password;
+    }
+    
+    public void setPassword(String password) {
+        this.password = password;
+    }
+    
+    public String getEmail() {
+        return email;
+    }
+    
+    public void setEmail(String email) {
+        this.email = email;
+    }
+    
+    public String getBio() {
+        return bio;
+    }
+    
+    public void setBio(String bio) {
+        this.bio = bio;
+    }
+    
+    public String getImage() {
+        return image;
+    }
+    
+    public void setImage(String image) {
+        this.image = image;
+    }
+    
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+    
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+    
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+    
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+    
+    public Set<Article> getArticles() {
+        return articles;
+    }
+    
+    public void setArticles(Set<Article> articles) {
+        this.articles = articles;
+    }
+    
+    public Set<Comment> getComments() {
+        return comments;
+    }
+    
+    public void setComments(Set<Comment> comments) {
+        this.comments = comments;
+    }
+    
+    public Set<User> getFollowing() {
+        return following;
+    }
+    
+    public void setFollowing(Set<User> following) {
+        this.following = following;
+    }
+    
+    public Set<User> getFollowers() {
+        return followers;
+    }
+    
+    public void setFollowers(Set<User> followers) {
+        this.followers = followers;
+    }
+    
+    public Set<Article> getFavoriteArticles() {
+        return favoriteArticles;
+    }
+    
+    public void setFavoriteArticles(Set<Article> favoriteArticles) {
+        this.favoriteArticles = favoriteArticles;
+    }
+    
+    public void follow(User user) {
+        this.following.add(user);
+        user.getFollowers().add(this);
+    }
+    
+    public void unfollow(User user) {
+        this.following.remove(user);
+        user.getFollowers().remove(this);
+    }
+    
+    public boolean isFollowing(User user) {
+        return this.following.contains(user);
+    }
+    
+    public void favoriteArticle(Article article) {
+        this.favoriteArticles.add(article);
+        article.getFavoritedBy().add(this);
+    }
+    
+    public void unfavoriteArticle(Article article) {
+        this.favoriteArticles.remove(article);
+        article.getFavoritedBy().remove(this);
+    }
+    
+    public boolean hasFavorited(Article article) {
+        return this.favoriteArticles.contains(article);
+    }
+}

--- a/TARGET/src/main/java/realworld/com/repository/ArticleRepository.java
+++ b/TARGET/src/main/java/realworld/com/repository/ArticleRepository.java
@@ -1,0 +1,32 @@
+package realworld.com.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import realworld.com.model.Article;
+import realworld.com.model.User;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+    
+    Optional<Article> findBySlug(String slug);
+    
+    Page<Article> findByAuthor(User author, Pageable pageable);
+    
+    @Query("SELECT a FROM Article a JOIN a.tags t WHERE t.name = :tag")
+    Page<Article> findByTagName(@Param("tag") String tag, Pageable pageable);
+    
+    @Query("SELECT a FROM Article a JOIN a.favoritedBy u WHERE u.username = :username")
+    Page<Article> findByFavoritedUsername(@Param("username") String username, Pageable pageable);
+    
+    @Query("SELECT a FROM Article a JOIN a.author u JOIN u.followers f WHERE f.id = :userId")
+    Page<Article> findByFollowedAuthors(@Param("userId") Long userId, Pageable pageable);
+    
+    boolean existsBySlug(String slug);
+}

--- a/TARGET/src/main/java/realworld/com/repository/CommentRepository.java
+++ b/TARGET/src/main/java/realworld/com/repository/CommentRepository.java
@@ -1,0 +1,16 @@
+package realworld.com.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import realworld.com.model.Article;
+import realworld.com.model.Comment;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    
+    List<Comment> findByArticleOrderByCreatedAtDesc(Article article);
+    
+    void deleteByArticleId(Long articleId);
+}

--- a/TARGET/src/main/java/realworld/com/repository/TagRepository.java
+++ b/TARGET/src/main/java/realworld/com/repository/TagRepository.java
@@ -1,0 +1,18 @@
+package realworld.com.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import realworld.com.model.Tag;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    
+    Optional<Tag> findByName(String name);
+    
+    List<Tag> findByNameIn(List<String> names);
+    
+    boolean existsByName(String name);
+}

--- a/TARGET/src/main/java/realworld/com/repository/UserRepository.java
+++ b/TARGET/src/main/java/realworld/com/repository/UserRepository.java
@@ -1,0 +1,19 @@
+package realworld.com.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import realworld.com.model.User;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    
+    Optional<User> findByEmail(String email);
+    
+    Optional<User> findByUsername(String username);
+    
+    boolean existsByUsername(String username);
+    
+    boolean existsByEmail(String email);
+}

--- a/TARGET/src/main/java/realworld/com/util/DateUtil.java
+++ b/TARGET/src/main/java/realworld/com/util/DateUtil.java
@@ -1,0 +1,24 @@
+package realworld.com.util;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+public class DateUtil {
+    
+    private static final DateTimeFormatter ISO8601_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    
+    public static String formatToISO8601(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
+        return dateTime.atZone(ZoneId.systemDefault()).format(ISO8601_FORMATTER);
+    }
+    
+    public static LocalDateTime parseFromISO8601(String dateTimeStr) {
+        if (dateTimeStr == null || dateTimeStr.isEmpty()) {
+            return null;
+        }
+        return LocalDateTime.parse(dateTimeStr, ISO8601_FORMATTER);
+    }
+}

--- a/TARGET/src/main/resources/application.properties
+++ b/TARGET/src/main/resources/application.properties
@@ -1,0 +1,22 @@
+# Database Configuration
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# JPA Configuration
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# Flyway Configuration
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+
+# Server Configuration
+server.port=8080
+
+# JWT Configuration
+jwt.secret=your-secret-key
+jwt.expiration=86400000

--- a/TARGET/src/main/resources/db/migration/V1__Create_initial_tables.sql
+++ b/TARGET/src/main/resources/db/migration/V1__Create_initial_tables.sql
@@ -1,0 +1,68 @@
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  username VARCHAR(255) NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  bio VARCHAR(1024),
+  image VARCHAR(255),
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  CONSTRAINT user_email_unique UNIQUE (email),
+  CONSTRAINT user_username_unique UNIQUE (username)
+);
+
+CREATE TABLE followers (
+  user_id INTEGER NOT NULL,
+  followee_id INTEGER NOT NULL,
+  inserted_at TIMESTAMP NOT NULL,
+  FOREIGN KEY (followee_id) REFERENCES users(id),
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  CONSTRAINT follower_follower_follwed_unq UNIQUE (user_id, followee_id)
+);
+
+CREATE TABLE articles (
+  id SERIAL PRIMARY KEY,
+  slug VARCHAR(255) NOT NULL,
+  title VARCHAR(300) NOT NULL,
+  description VARCHAR(255) NOT NULL,
+  body TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  author_id INTEGER NOT NULL,
+  FOREIGN KEY (author_id) REFERENCES users(id),
+  CONSTRAINT articles_slug_unique UNIQUE(slug)
+);
+
+CREATE TABLE tags (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  CONSTRAINT tag_name_unique UNIQUE(name)
+);
+
+CREATE TABLE articles_tags (
+  id SERIAL PRIMARY KEY,
+  article_id INTEGER NOT NULL,
+  tag_id INTEGER NOT NULL,
+  FOREIGN KEY (article_id) REFERENCES articles(id),
+  FOREIGN KEY (tag_id) REFERENCES tags(id),
+  CONSTRAINT article_tag_id_unique UNIQUE(article_id, tag_id)
+);
+
+CREATE TABLE comments (
+  id SERIAL PRIMARY KEY,
+  body VARCHAR (4096) NOT NULL,
+  article_id INTEGER NOT NULL,
+  author_id INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  FOREIGN KEY (article_id) REFERENCES articles(id),
+  FOREIGN KEY (author_id) REFERENCES users(id)
+);
+
+CREATE TABLE favorite (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL,
+  favorited_id INTEGER NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  FOREIGN KEY (favorited_id) REFERENCES articles(id)
+);


### PR DESCRIPTION
This PR migrates the Slick models to JPA entities for the Java migration project.

Changes:
- Created Maven project structure with Spring Boot dependencies
- Migrated database schema to JPA entities
- Added Spring Data JPA repositories
- Added DTOs for API communication
- Added utility classes for date formatting

The migration preserves the existing data model and relationships while adapting them to the JPA specification.