### PR TITLE
Migrate Slick models to JPA entities

### DIFF
--- a/TARGET/pom.xml
+++ b/TARGET/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>realworld.com</groupId>
+    <artifactId>realworld-app</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>realworld-app</name>
+    <description>Real World Application migrated from Scala to Java</description>
+    
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>3.5.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.flywaydb</groupId>
+                <artifactId>flyway-maven-plugin</artifactId>
+                <version>${flyway.version}</version>
+                <configuration>
+                    <locations>
+                        <location>classpath:db/migration</location>
+                    </locations>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/TARGET/src/main/java/realworld/com/RealWorldApplication.java
+++ b/TARGET/src/main/java/realworld/com/RealWorldApplication.java
@@ -1,0 +1,14 @@
+package realworld.com;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@SpringBootApplication
+@EnableJpaAuditing
+public class RealWorldApplication {
+    
+    public static void main(String[] args) {
+        SpringApplication.run(RealWorldApplication.class, args);
+    }
+}

--- a/TARGET/src/main/java/realworld/com/articles/Article.java
+++ b/TARGET/src/main/java/realworld/com/articles/Article.java
@@ -1,0 +1,185 @@
+package realworld.com.articles;
+
+import jakarta.persistence.*;
+import realworld.com.users.User;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "articles")
+public class Article {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false, unique = true)
+    private String slug;
+    
+    @Column(nullable = false)
+    private String title;
+    
+    @Column(nullable = false)
+    private String description;
+    
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String body;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+    
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+    
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+    
+    @ManyToMany
+    @JoinTable(
+        name = "articles_tags",
+        joinColumns = @JoinColumn(name = "article_id"),
+        inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private Set<Tag> tags = new HashSet<>();
+    
+    @ManyToMany
+    @JoinTable(
+        name = "favorite",
+        joinColumns = @JoinColumn(name = "favorited_id"),
+        inverseJoinColumns = @JoinColumn(name = "user_id")
+    )
+    private Set<User> favoritedBy = new HashSet<>();
+    
+    // Default constructor required by JPA
+    public Article() {
+    }
+    
+    public Article(Long id, String slug, String title, String description, String body, User author, Instant createdAt, Instant updatedAt) {
+        this.id = id;
+        this.slug = slug;
+        this.title = title;
+        this.description = description;
+        this.body = body;
+        this.author = author;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+    
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getSlug() {
+        return slug;
+    }
+    
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+    
+    public String getTitle() {
+        return title;
+    }
+    
+    public void setTitle(String title) {
+        this.title = title;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    
+    public String getBody() {
+        return body;
+    }
+    
+    public void setBody(String body) {
+        this.body = body;
+    }
+    
+    public User getAuthor() {
+        return author;
+    }
+    
+    public void setAuthor(User author) {
+        this.author = author;
+    }
+    
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+    
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+    
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+    
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+    
+    public Set<Tag> getTags() {
+        return tags;
+    }
+    
+    public void setTags(Set<Tag> tags) {
+        this.tags = tags;
+    }
+    
+    public Set<User> getFavoritedBy() {
+        return favoritedBy;
+    }
+    
+    public void setFavoritedBy(Set<User> favoritedBy) {
+        this.favoritedBy = favoritedBy;
+    }
+    
+    public void addTag(Tag tag) {
+        tags.add(tag);
+    }
+    
+    public void removeTag(Tag tag) {
+        tags.remove(tag);
+    }
+    
+    public void addToFavorites(User user) {
+        favoritedBy.add(user);
+    }
+    
+    public void removeFromFavorites(User user) {
+        favoritedBy.remove(user);
+    }
+    
+    public boolean isFavoritedBy(User user) {
+        return favoritedBy.contains(user);
+    }
+    
+    public int getFavoritesCount() {
+        return favoritedBy.size();
+    }
+    
+    @PrePersist
+    protected void onCreate() {
+        createdAt = Instant.now();
+        updatedAt = Instant.now();
+    }
+    
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/TARGET/src/main/java/realworld/com/articles/ArticleRepository.java
+++ b/TARGET/src/main/java/realworld/com/articles/ArticleRepository.java
@@ -1,0 +1,27 @@
+package realworld.com.articles;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import realworld.com.users.User;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+    
+    Optional<Article> findBySlug(String slug);
+    
+    Page<Article> findByAuthor(User author, Pageable pageable);
+    
+    @Query("SELECT a FROM Article a JOIN a.tags t WHERE t.name = :tag")
+    Page<Article> findByTag(@Param("tag") String tag, Pageable pageable);
+    
+    @Query("SELECT a FROM Article a JOIN a.favoritedBy u WHERE u = :user")
+    Page<Article> findByFavoritedBy(@Param("user") User user, Pageable pageable);
+    
+    @Query("SELECT a FROM Article a WHERE a.author IN :authors")
+    Page<Article> findByAuthors(@Param("authors") List<User> authors, Pageable pageable);
+}

--- a/TARGET/src/main/java/realworld/com/articles/ArticleTag.java
+++ b/TARGET/src/main/java/realworld/com/articles/ArticleTag.java
@@ -1,0 +1,55 @@
+package realworld.com.articles;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "articles_tags")
+public class ArticleTag {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+    
+    @ManyToOne
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+    
+    // Default constructor required by JPA
+    public ArticleTag() {
+    }
+    
+    public ArticleTag(Long id, Article article, Tag tag) {
+        this.id = id;
+        this.article = article;
+        this.tag = tag;
+    }
+    
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public Article getArticle() {
+        return article;
+    }
+    
+    public void setArticle(Article article) {
+        this.article = article;
+    }
+    
+    public Tag getTag() {
+        return tag;
+    }
+    
+    public void setTag(Tag tag) {
+        this.tag = tag;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/articles/ArticleTagRepository.java
+++ b/TARGET/src/main/java/realworld/com/articles/ArticleTagRepository.java
@@ -1,0 +1,11 @@
+package realworld.com.articles;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface ArticleTagRepository extends JpaRepository<ArticleTag, Long> {
+    
+    List<ArticleTag> findByArticle(Article article);
+    
+    void deleteByArticleAndTag(Article article, Tag tag);
+}

--- a/TARGET/src/main/java/realworld/com/articles/Favorite.java
+++ b/TARGET/src/main/java/realworld/com/articles/Favorite.java
@@ -1,0 +1,56 @@
+package realworld.com.articles;
+
+import jakarta.persistence.*;
+import realworld.com.users.User;
+
+@Entity
+@Table(name = "favorite")
+public class Favorite {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+    
+    @ManyToOne
+    @JoinColumn(name = "favorited_id", nullable = false)
+    private Article article;
+    
+    // Default constructor required by JPA
+    public Favorite() {
+    }
+    
+    public Favorite(Long id, User user, Article article) {
+        this.id = id;
+        this.user = user;
+        this.article = article;
+    }
+    
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public User getUser() {
+        return user;
+    }
+    
+    public void setUser(User user) {
+        this.user = user;
+    }
+    
+    public Article getArticle() {
+        return article;
+    }
+    
+    public void setArticle(Article article) {
+        this.article = article;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/articles/FavoriteRepository.java
+++ b/TARGET/src/main/java/realworld/com/articles/FavoriteRepository.java
@@ -1,0 +1,14 @@
+package realworld.com.articles;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import realworld.com.users.User;
+import java.util.Optional;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+    
+    Optional<Favorite> findByUserAndArticle(User user, Article article);
+    
+    boolean existsByUserAndArticle(User user, Article article);
+    
+    int countByArticle(Article article);
+}

--- a/TARGET/src/main/java/realworld/com/articles/Tag.java
+++ b/TARGET/src/main/java/realworld/com/articles/Tag.java
@@ -1,0 +1,75 @@
+package realworld.com.articles;
+
+import jakarta.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "tags")
+public class Tag {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false, unique = true)
+    private String name;
+    
+    @ManyToMany(mappedBy = "tags")
+    private Set<Article> articles = new HashSet<>();
+    
+    // Default constructor required by JPA
+    public Tag() {
+    }
+    
+    public Tag(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+    
+    public static Tag create(String tagName) {
+        Tag tag = new Tag();
+        tag.setName(tagName);
+        return tag;
+    }
+    
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public Set<Article> getArticles() {
+        return articles;
+    }
+    
+    public void setArticles(Set<Article> articles) {
+        this.articles = articles;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        
+        Tag tag = (Tag) o;
+        
+        return name != null ? name.equals(tag.name) : tag.name == null;
+    }
+    
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 0;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/articles/TagRepository.java
+++ b/TARGET/src/main/java/realworld/com/articles/TagRepository.java
@@ -1,0 +1,9 @@
+package realworld.com.articles;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    
+    Optional<Tag> findByName(String name);
+}

--- a/TARGET/src/main/java/realworld/com/articles/comments/Comment.java
+++ b/TARGET/src/main/java/realworld/com/articles/comments/Comment.java
@@ -1,0 +1,113 @@
+package realworld.com.articles.comments;
+
+import jakarta.persistence.*;
+import realworld.com.articles.Article;
+import realworld.com.users.User;
+import java.time.Instant;
+
+@Entity
+@Table(name = "comments")
+public class Comment {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false, length = 4096)
+    private String body;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+    
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+    
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+    
+    // Default constructor required by JPA
+    public Comment() {
+    }
+    
+    public Comment(Long id, String body, Article article, User author, Instant createdAt, Instant updatedAt) {
+        this.id = id;
+        this.body = body;
+        this.article = article;
+        this.author = author;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+    
+    public static Comment create(String body, Article article, User author) {
+        Comment comment = new Comment();
+        comment.setBody(body);
+        comment.setArticle(article);
+        comment.setAuthor(author);
+        return comment;
+    }
+    
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getBody() {
+        return body;
+    }
+    
+    public void setBody(String body) {
+        this.body = body;
+    }
+    
+    public Article getArticle() {
+        return article;
+    }
+    
+    public void setArticle(Article article) {
+        this.article = article;
+    }
+    
+    public User getAuthor() {
+        return author;
+    }
+    
+    public void setAuthor(User author) {
+        this.author = author;
+    }
+    
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+    
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+    
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+    
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+    
+    @PrePersist
+    protected void onCreate() {
+        createdAt = Instant.now();
+        updatedAt = Instant.now();
+    }
+    
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/TARGET/src/main/java/realworld/com/articles/comments/CommentRepository.java
+++ b/TARGET/src/main/java/realworld/com/articles/comments/CommentRepository.java
@@ -1,0 +1,10 @@
+package realworld.com.articles.comments;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import realworld.com.articles.Article;
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    
+    List<Comment> findByArticleOrderByCreatedAtDesc(Article article);
+}

--- a/TARGET/src/main/java/realworld/com/profile/Profile.java
+++ b/TARGET/src/main/java/realworld/com/profile/Profile.java
@@ -1,0 +1,70 @@
+package realworld.com.profile;
+
+import java.util.Objects;
+
+public class Profile {
+    
+    private String username;
+    private String bio;
+    private String image;
+    private boolean following;
+    
+    public Profile() {
+    }
+    
+    public Profile(String username, String bio, String image, boolean following) {
+        this.username = username;
+        this.bio = bio;
+        this.image = image;
+        this.following = following;
+    }
+    
+    // Getters and Setters
+    public String getUsername() {
+        return username;
+    }
+    
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    
+    public String getBio() {
+        return bio;
+    }
+    
+    public void setBio(String bio) {
+        this.bio = bio;
+    }
+    
+    public String getImage() {
+        return image;
+    }
+    
+    public void setImage(String image) {
+        this.image = image;
+    }
+    
+    public boolean isFollowing() {
+        return following;
+    }
+    
+    public void setFollowing(boolean following) {
+        this.following = following;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Profile profile = (Profile) o;
+        return following == profile.following &&
+               Objects.equals(username, profile.username) &&
+               Objects.equals(bio, profile.bio) &&
+               Objects.equals(image, profile.image);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(username, bio, image, following);
+    }
+}

--- a/TARGET/src/main/java/realworld/com/profile/UserFollower.java
+++ b/TARGET/src/main/java/realworld/com/profile/UserFollower.java
@@ -1,0 +1,75 @@
+package realworld.com.profile;
+
+import jakarta.persistence.*;
+import realworld.com.users.User;
+import java.time.Instant;
+
+@Entity
+@Table(name = "followers")
+public class UserFollower {
+    
+    @EmbeddedId
+    private UserFollowerId id;
+    
+    @ManyToOne
+    @MapsId("userId")
+    @JoinColumn(name = "user_id")
+    private User user;
+    
+    @ManyToOne
+    @MapsId("followeeId")
+    @JoinColumn(name = "followee_id")
+    private User followee;
+    
+    @Column(name = "inserted_at", nullable = false)
+    private Instant insertedAt;
+    
+    // Default constructor required by JPA
+    public UserFollower() {
+    }
+    
+    public UserFollower(User user, User followee, Instant insertedAt) {
+        this.id = new UserFollowerId(user.getId(), followee.getId());
+        this.user = user;
+        this.followee = followee;
+        this.insertedAt = insertedAt;
+    }
+    
+    // Getters and Setters
+    public UserFollowerId getId() {
+        return id;
+    }
+    
+    public void setId(UserFollowerId id) {
+        this.id = id;
+    }
+    
+    public User getUser() {
+        return user;
+    }
+    
+    public void setUser(User user) {
+        this.user = user;
+    }
+    
+    public User getFollowee() {
+        return followee;
+    }
+    
+    public void setFollowee(User followee) {
+        this.followee = followee;
+    }
+    
+    public Instant getInsertedAt() {
+        return insertedAt;
+    }
+    
+    public void setInsertedAt(Instant insertedAt) {
+        this.insertedAt = insertedAt;
+    }
+    
+    @PrePersist
+    protected void onCreate() {
+        insertedAt = Instant.now();
+    }
+}

--- a/TARGET/src/main/java/realworld/com/profile/UserFollowerId.java
+++ b/TARGET/src/main/java/realworld/com/profile/UserFollowerId.java
@@ -1,0 +1,56 @@
+package realworld.com.profile;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class UserFollowerId implements Serializable {
+    
+    @Column(name = "user_id")
+    private Long userId;
+    
+    @Column(name = "followee_id")
+    private Long followeeId;
+    
+    // Default constructor required by JPA
+    public UserFollowerId() {
+    }
+    
+    public UserFollowerId(Long userId, Long followeeId) {
+        this.userId = userId;
+        this.followeeId = followeeId;
+    }
+    
+    // Getters and Setters
+    public Long getUserId() {
+        return userId;
+    }
+    
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+    
+    public Long getFolloweeId() {
+        return followeeId;
+    }
+    
+    public void setFolloweeId(Long followeeId) {
+        this.followeeId = followeeId;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserFollowerId that = (UserFollowerId) o;
+        return Objects.equals(userId, that.userId) &&
+               Objects.equals(followeeId, that.followeeId);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, followeeId);
+    }
+}

--- a/TARGET/src/main/java/realworld/com/profile/UserFollowerRepository.java
+++ b/TARGET/src/main/java/realworld/com/profile/UserFollowerRepository.java
@@ -1,0 +1,12 @@
+package realworld.com.profile;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import realworld.com.users.User;
+import java.util.Optional;
+
+public interface UserFollowerRepository extends JpaRepository<UserFollower, UserFollowerId> {
+    
+    Optional<UserFollower> findByUserAndFollowee(User user, User followee);
+    
+    boolean existsByUserAndFollowee(User user, User followee);
+}

--- a/TARGET/src/main/java/realworld/com/users/User.java
+++ b/TARGET/src/main/java/realworld/com/users/User.java
@@ -1,0 +1,167 @@
+package realworld.com.users;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+public class User {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false, unique = true)
+    private String username;
+    
+    @Column(nullable = false)
+    private String password;
+    
+    @Column(nullable = false, unique = true)
+    private String email;
+    
+    @Column(length = 1024)
+    private String bio;
+    
+    private String image;
+    
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+    
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+    
+    @ManyToMany
+    @JoinTable(
+        name = "followers",
+        joinColumns = @JoinColumn(name = "user_id"),
+        inverseJoinColumns = @JoinColumn(name = "followee_id")
+    )
+    private Set<User> following = new HashSet<>();
+    
+    @ManyToMany(mappedBy = "following")
+    private Set<User> followers = new HashSet<>();
+    
+    // Default constructor required by JPA
+    public User() {
+    }
+    
+    public User(Long id, String username, String password, String email, String bio, String image, Instant createdAt, Instant updatedAt) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.bio = bio;
+        this.image = image;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+    
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getUsername() {
+        return username;
+    }
+    
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    
+    public String getPassword() {
+        return password;
+    }
+    
+    public void setPassword(String password) {
+        this.password = password;
+    }
+    
+    public String getEmail() {
+        return email;
+    }
+    
+    public void setEmail(String email) {
+        this.email = email;
+    }
+    
+    public String getBio() {
+        return bio;
+    }
+    
+    public void setBio(String bio) {
+        this.bio = bio;
+    }
+    
+    public String getImage() {
+        return image;
+    }
+    
+    public void setImage(String image) {
+        this.image = image;
+    }
+    
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+    
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+    
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+    
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+    
+    public Set<User> getFollowing() {
+        return following;
+    }
+    
+    public void setFollowing(Set<User> following) {
+        this.following = following;
+    }
+    
+    public Set<User> getFollowers() {
+        return followers;
+    }
+    
+    public void setFollowers(Set<User> followers) {
+        this.followers = followers;
+    }
+    
+    public void follow(User user) {
+        following.add(user);
+        user.getFollowers().add(this);
+    }
+    
+    public void unfollow(User user) {
+        following.remove(user);
+        user.getFollowers().remove(this);
+    }
+    
+    public boolean isFollowing(User user) {
+        return following.contains(user);
+    }
+    
+    @PrePersist
+    protected void onCreate() {
+        createdAt = Instant.now();
+        updatedAt = Instant.now();
+    }
+    
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/TARGET/src/main/java/realworld/com/users/UserRepository.java
+++ b/TARGET/src/main/java/realworld/com/users/UserRepository.java
@@ -1,0 +1,15 @@
+package realworld.com.users;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    
+    Optional<User> findByEmail(String email);
+    
+    Optional<User> findByUsername(String username);
+    
+    boolean existsByUsername(String username);
+    
+    boolean existsByEmail(String email);
+}

--- a/TARGET/src/main/java/realworld/com/utils/SlugUtils.java
+++ b/TARGET/src/main/java/realworld/com/utils/SlugUtils.java
@@ -1,0 +1,17 @@
+package realworld.com.utils;
+
+public class SlugUtils {
+    
+    /**
+     * Converts a title to a URL-friendly slug
+     * 
+     * @param title The title to slugify
+     * @return The slugified title
+     */
+    public static String slugify(String title) {
+        if (title == null) {
+            return "";
+        }
+        return title.toLowerCase().replaceAll("\\s", "-");
+    }
+}

--- a/TARGET/src/main/resources/application.properties
+++ b/TARGET/src/main/resources/application.properties
@@ -1,0 +1,19 @@
+# Database Configuration
+spring.datasource.url=jdbc:postgresql://localhost:5432/realworld
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# JPA Configuration
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# Flyway Configuration
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+
+# JWT Configuration
+jwt.secret=secretkey
+jwt.expiration=86400000

--- a/TARGET/src/main/resources/db/migration/V1__Create_initial_tables.sql
+++ b/TARGET/src/main/resources/db/migration/V1__Create_initial_tables.sql
@@ -1,0 +1,68 @@
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  username VARCHAR(255) NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  bio VARCHAR(1024),
+  image VARCHAR(255),
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  CONSTRAINT user_email_unique UNIQUE (email),
+  CONSTRAINT user_username_unique UNIQUE (username)
+);
+
+CREATE TABLE followers (
+  user_id INTEGER NOT NULL,
+  followee_id INTEGER NOT NULL,
+  inserted_at TIMESTAMP NOT NULL,
+  FOREIGN KEY (followee_id) REFERENCES users(id),
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  CONSTRAINT follower_follower_follwed_unq UNIQUE (user_id, followee_id)
+);
+
+CREATE TABLE articles (
+  id SERIAL PRIMARY KEY,
+  slug VARCHAR(255) NOT NULL,
+  title VARCHAR(300) NOT NULL,
+  description VARCHAR(255) NOT NULL,
+  body TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  author_id INTEGER NOT NULL,
+  FOREIGN KEY (author_id) REFERENCES users(id),
+  CONSTRAINT articles_slug_unique UNIQUE(slug)
+);
+
+CREATE TABLE tags (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  CONSTRAINT tag_name_unique UNIQUE(name)
+);
+
+CREATE TABLE articles_tags (
+  id SERIAL PRIMARY KEY,
+  article_id INTEGER NOT NULL,
+  tag_id INTEGER NOT NULL,
+  FOREIGN KEY (article_id) REFERENCES articles(id),
+  FOREIGN KEY (tag_id) REFERENCES tags(id),
+  CONSTRAINT article_tag_id_unique UNIQUE(article_id, tag_id)
+);
+
+CREATE TABLE comments (
+  id SERIAL PRIMARY KEY,
+  body VARCHAR (4096) NOT NULL,
+  article_id INTEGER NOT NULL,
+  author_id INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  FOREIGN KEY (article_id) REFERENCES articles(id),
+  FOREIGN KEY (author_id) REFERENCES users(id)
+);
+
+CREATE TABLE favorite (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL,
+  favorited_id INTEGER NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  FOREIGN KEY (favorited_id) REFERENCES articles(id)
+)


### PR DESCRIPTION
This PR migrates the Slick models to JPA entities for the Java migration.

Changes include:
- Created JPA entity classes for all Slick models
- Added JPA annotations for entity relationships
- Created Spring Data JPA repositories
- Set up Maven project structure with Spring Boot dependencies
- Configured application properties for database connection
- Copied SQL migration scripts

The migration preserves the existing data model structure while adapting it to JPA conventions.