### PR TITLE
Migrate data models from Scala to Java with JPA

### DIFF
--- a/TARGET/pom.xml
+++ b/TARGET/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>realworld.com</groupId>
+    <artifactId>realworld-spring-boot</artifactId>
+    <version>0.1.0</version>
+    <name>realworld-spring-boot</name>
+    <description>RealWorld API implementation with Spring Boot</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <!-- Spring Boot Starters -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <!-- Database -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+
+        <!-- JWT -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/TARGET/src/main/java/realworld/com/RealWorldApplication.java
+++ b/TARGET/src/main/java/realworld/com/RealWorldApplication.java
@@ -1,0 +1,12 @@
+package realworld.com;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class RealWorldApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(RealWorldApplication.class, args);
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Article.java
+++ b/TARGET/src/main/java/realworld/com/model/Article.java
@@ -1,0 +1,174 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "articles")
+public class Article {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String slug;
+
+    @Column(nullable = false, length = 300)
+    private String title;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String body;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @ManyToMany
+    @JoinTable(
+        name = "articles_tags",
+        joinColumns = @JoinColumn(name = "article_id"),
+        inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private Set<Tag> tags = new HashSet<>();
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Comment> comments = new HashSet<>();
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Favorite> favorites = new HashSet<>();
+
+    // Default constructor required by JPA
+    public Article() {
+    }
+
+    public Article(Long id, String slug, String title, String description, String body, 
+                  User author, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.slug = slug;
+        this.title = title;
+        this.description = description;
+        this.body = body;
+        this.author = author;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // Getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public User getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(User author) {
+        this.author = author;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Set<Tag> getTags() {
+        return tags;
+    }
+
+    public void setTags(Set<Tag> tags) {
+        this.tags = tags;
+    }
+
+    public Set<Comment> getComments() {
+        return comments;
+    }
+
+    public void setComments(Set<Comment> comments) {
+        this.comments = comments;
+    }
+
+    public Set<Favorite> getFavorites() {
+        return favorites;
+    }
+
+    public void setFavorites(Set<Favorite> favorites) {
+        this.favorites = favorites;
+    }
+
+    public void addTag(Tag tag) {
+        tags.add(tag);
+    }
+
+    public void removeTag(Tag tag) {
+        tags.remove(tag);
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/ArticleTag.java
+++ b/TARGET/src/main/java/realworld/com/model/ArticleTag.java
@@ -1,0 +1,58 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+
+/**
+ * This class represents the many-to-many relationship between Articles and Tags.
+ * In the database schema, this is represented by the articles_tags table,
+ * but in JPA we're using a @ManyToMany relationship in the Article entity.
+ * This class is kept for reference but is not actively used in the JPA model.
+ */
+@Entity
+@Table(name = "articles_tags")
+public class ArticleTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "article_id", nullable = false)
+    private Long articleId;
+
+    @Column(name = "tag_id", nullable = false)
+    private Long tagId;
+
+    // Default constructor required by JPA
+    public ArticleTag() {
+    }
+
+    public ArticleTag(Long id, Long articleId, Long tagId) {
+        this.id = id;
+        this.articleId = articleId;
+        this.tagId = tagId;
+    }
+
+    // Getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getArticleId() {
+        return articleId;
+    }
+
+    public void setArticleId(Long articleId) {
+        this.articleId = articleId;
+    }
+
+    public Long getTagId() {
+        return tagId;
+    }
+
+    public void setTagId(Long tagId) {
+        this.tagId = tagId;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Comment.java
+++ b/TARGET/src/main/java/realworld/com/model/Comment.java
@@ -1,0 +1,103 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "comments")
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 4096)
+    private String body;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id", nullable = false)
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    // Default constructor required by JPA
+    public Comment() {
+    }
+
+    public Comment(Long id, String body, Article article, User author, 
+                  LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.body = body;
+        this.article = article;
+        this.author = author;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // Getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public Article getArticle() {
+        return article;
+    }
+
+    public void setArticle(Article article) {
+        this.article = article;
+    }
+
+    public User getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(User author) {
+        this.author = author;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Favorite.java
+++ b/TARGET/src/main/java/realworld/com/model/Favorite.java
@@ -1,0 +1,68 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "favorite")
+public class Favorite {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "favorited_id", nullable = false)
+    private Article article;
+
+    // Default constructor required by JPA
+    public Favorite() {
+    }
+
+    public Favorite(Long id, User user, Article article) {
+        this.id = id;
+        this.user = user;
+        this.article = article;
+    }
+
+    // Getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Article getArticle() {
+        return article;
+    }
+
+    public void setArticle(Article article) {
+        this.article = article;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Favorite)) return false;
+        Favorite favorite = (Favorite) o;
+        return user.getId().equals(favorite.user.getId()) &&
+               article.getId().equals(favorite.article.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * user.getId().hashCode() + article.getId().hashCode();
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Profile.java
+++ b/TARGET/src/main/java/realworld/com/model/Profile.java
@@ -1,0 +1,66 @@
+package realworld.com.model;
+
+/**
+ * This class represents a user profile view.
+ * It's not an entity but a projection of User data.
+ */
+public class Profile {
+    private String username;
+    private String bio;
+    private String image;
+    private boolean following;
+
+    // Default constructor
+    public Profile() {
+    }
+
+    public Profile(String username, String bio, String image, boolean following) {
+        this.username = username;
+        this.bio = bio;
+        this.image = image;
+        this.following = following;
+    }
+
+    // Factory method to create a Profile from a User
+    public static Profile fromUser(User user, boolean following) {
+        return new Profile(
+            user.getUsername(),
+            user.getBio(),
+            user.getImage(),
+            following
+        );
+    }
+
+    // Getters and setters
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public void setBio(String bio) {
+        this.bio = bio;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public boolean isFollowing() {
+        return following;
+    }
+
+    public void setFollowing(boolean following) {
+        this.following = following;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Tag.java
+++ b/TARGET/src/main/java/realworld/com/model/Tag.java
@@ -1,0 +1,66 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "tags")
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @ManyToMany(mappedBy = "tags")
+    private Set<Article> articles = new HashSet<>();
+
+    // Default constructor required by JPA
+    public Tag() {
+    }
+
+    public Tag(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    // Getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<Article> getArticles() {
+        return articles;
+    }
+
+    public void setArticles(Set<Article> articles) {
+        this.articles = articles;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Tag)) return false;
+        Tag tag = (Tag) o;
+        return name.equals(tag.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/User.java
+++ b/TARGET/src/main/java/realworld/com/model/User.java
@@ -1,0 +1,164 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(length = 1024)
+    private String bio;
+
+    private String image;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @OneToMany(mappedBy = "user")
+    private Set<Favorite> favorites = new HashSet<>();
+
+    @ManyToMany
+    @JoinTable(
+        name = "followers",
+        joinColumns = @JoinColumn(name = "user_id"),
+        inverseJoinColumns = @JoinColumn(name = "followee_id")
+    )
+    private Set<User> following = new HashSet<>();
+
+    @ManyToMany(mappedBy = "following")
+    private Set<User> followers = new HashSet<>();
+
+    // Default constructor required by JPA
+    public User() {
+    }
+
+    public User(Long id, String username, String password, String email, String bio, String image, 
+                LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.bio = bio;
+        this.image = image;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // Getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public void setBio(String bio) {
+        this.bio = bio;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Set<Favorite> getFavorites() {
+        return favorites;
+    }
+
+    public void setFavorites(Set<Favorite> favorites) {
+        this.favorites = favorites;
+    }
+
+    public Set<User> getFollowing() {
+        return following;
+    }
+
+    public void setFollowing(Set<User> following) {
+        this.following = following;
+    }
+
+    public Set<User> getFollowers() {
+        return followers;
+    }
+
+    public void setFollowers(Set<User> followers) {
+        this.followers = followers;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/UserFollower.java
+++ b/TARGET/src/main/java/realworld/com/model/UserFollower.java
@@ -1,0 +1,75 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * This class represents the followers relationship between users.
+ * In the database schema, this is represented by the followers table,
+ * but in JPA we're using a @ManyToMany relationship in the User entity.
+ * This class is kept for reference but is not actively used in the JPA model.
+ */
+@Entity
+@Table(name = "followers")
+public class UserFollower {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "followee_id", nullable = false)
+    private Long followeeId;
+
+    @Column(name = "inserted_at", nullable = false)
+    private LocalDateTime insertedAt;
+
+    // Default constructor required by JPA
+    public UserFollower() {
+    }
+
+    public UserFollower(Long userId, Long followeeId, LocalDateTime insertedAt) {
+        this.userId = userId;
+        this.followeeId = followeeId;
+        this.insertedAt = insertedAt;
+    }
+
+    // Getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Long getFolloweeId() {
+        return followeeId;
+    }
+
+    public void setFolloweeId(Long followeeId) {
+        this.followeeId = followeeId;
+    }
+
+    public LocalDateTime getInsertedAt() {
+        return insertedAt;
+    }
+
+    public void setInsertedAt(LocalDateTime insertedAt) {
+        this.insertedAt = insertedAt;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        insertedAt = LocalDateTime.now();
+    }
+}

--- a/TARGET/src/main/resources/application.properties
+++ b/TARGET/src/main/resources/application.properties
@@ -1,0 +1,28 @@
+# Server configuration
+server.port=9000
+
+# Database configuration
+spring.datasource.url=jdbc:postgresql://localhost:5432/real_world_dev
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# JPA/Hibernate configuration
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# Flyway configuration
+spring.flyway.enabled=true
+spring.flyway.baseline-on-migrate=true
+
+# JWT configuration
+jwt.secret=secret
+jwt.expiration=86400000
+
+# Environment variable overrides
+spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/real_world_dev}
+spring.datasource.username=${DB_USER:postgres}
+spring.datasource.password=${DB_PASS:postgres}
+jwt.secret=${SECRET_KEY:secret}

--- a/TARGET/src/main/resources/db/migration/V1__Create_initial_tables.sql
+++ b/TARGET/src/main/resources/db/migration/V1__Create_initial_tables.sql
@@ -1,0 +1,68 @@
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  username VARCHAR(255) NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  bio VARCHAR(1024),
+  image VARCHAR(255),
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  CONSTRAINT user_email_unique UNIQUE (email),
+  CONSTRAINT user_username_unique UNIQUE (username)
+);
+
+CREATE TABLE followers (
+  user_id INTEGER NOT NULL,
+  followee_id INTEGER NOT NULL,
+  inserted_at TIMESTAMP NOT NULL,
+  FOREIGN KEY (followee_id) REFERENCES users(id),
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  CONSTRAINT follower_follower_follwed_unq UNIQUE (user_id, followee_id)
+);
+
+CREATE TABLE articles (
+  id SERIAL PRIMARY KEY,
+  slug VARCHAR(255) NOT NULL,
+  title VARCHAR(300) NOT NULL,
+  description VARCHAR(255) NOT NULL,
+  body TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  author_id INTEGER NOT NULL,
+  FOREIGN KEY (author_id) REFERENCES users(id),
+  CONSTRAINT articles_slug_unique UNIQUE(slug)
+);
+
+CREATE TABLE tags (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  CONSTRAINT tag_name_unique UNIQUE(name)
+);
+
+CREATE TABLE articles_tags (
+  id SERIAL PRIMARY KEY,
+  article_id INTEGER NOT NULL,
+  tag_id INTEGER NOT NULL,
+  FOREIGN KEY (article_id) REFERENCES articles(id),
+  FOREIGN KEY (tag_id) REFERENCES tags(id),
+  CONSTRAINT article_tag_id_unique UNIQUE(article_id, tag_id)
+);
+
+CREATE TABLE comments (
+  id SERIAL PRIMARY KEY,
+  body VARCHAR (4096) NOT NULL,
+  article_id INTEGER NOT NULL,
+  author_id INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  FOREIGN KEY (article_id) REFERENCES articles(id),
+  FOREIGN KEY (author_id) REFERENCES users(id)
+);
+
+CREATE TABLE favorite (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL,
+  favorited_id INTEGER NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  FOREIGN KEY (favorited_id) REFERENCES articles(id)
+)


### PR DESCRIPTION
This PR migrates the data models from Scala to Java using JPA annotations.

Changes include:
- Created Java model classes with JPA annotations in TARGET/src/main/java/realworld/com/model/
- Added Maven pom.xml with Spring Boot dependencies
- Added Spring Boot application.properties
- Copied Flyway migration script
- Added Spring Boot main application class

All models have been migrated to use JPA annotations and proper relationships between entities have been established. The models include:
- User
- Article
- Tag
- Comment
- Favorite
- UserFollower (reference only)
- ArticleTag (reference only)
- Profile (view model)

The migration preserves all the fields and relationships from the original Scala models.