### PR TITLE
Convert Scala data models to Java JPA entities

### DIFF
--- a/TARGET/pom.xml
+++ b/TARGET/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>realworld.com</groupId>
+    <artifactId>realworld-app</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>realworld-app</name>
+    <description>RealWorld application migrated from Scala to Java</description>
+    
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>3.5.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/TARGET/src/main/java/realworld/com/model/Article.java
+++ b/TARGET/src/main/java/realworld/com/model/Article.java
@@ -1,0 +1,154 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "articles")
+public class Article {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(unique = true)
+    private String slug;
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String description;
+
+    @NotBlank
+    @Column(columnDefinition = "TEXT")
+    private String body;
+
+    @Column(name = "author_id")
+    private Long authorId;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "articles_tags",
+        joinColumns = @JoinColumn(name = "article_id"),
+        inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private Set<Tag> tags = new HashSet<>();
+
+    // Default constructor required by JPA
+    public Article() {
+    }
+
+    public Article(Long id, String slug, String title, String description, String body, Long authorId, Instant createdAt, Instant updatedAt) {
+        this.id = id;
+        this.slug = slug;
+        this.title = title;
+        this.description = description;
+        this.body = body;
+        this.authorId = authorId;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = Instant.now();
+        updatedAt = Instant.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    // Helper method to slugify title
+    public static String slugify(String title) {
+        return title.toLowerCase().replaceAll("\\s", "-");
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public Long getAuthorId() {
+        return authorId;
+    }
+
+    public void setAuthorId(Long authorId) {
+        this.authorId = authorId;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public Set<Tag> getTags() {
+        return tags;
+    }
+
+    public void setTags(Set<Tag> tags) {
+        this.tags = tags;
+    }
+
+    public void addTag(Tag tag) {
+        this.tags.add(tag);
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/ArticleTag.java
+++ b/TARGET/src/main/java/realworld/com/model/ArticleTag.java
@@ -1,0 +1,52 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "articles_tags")
+public class ArticleTag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "article_id")
+    private Long articleId;
+
+    @Column(name = "tag_id")
+    private Long tagId;
+
+    // Default constructor required by JPA
+    public ArticleTag() {
+    }
+
+    public ArticleTag(Long id, Long articleId, Long tagId) {
+        this.id = id;
+        this.articleId = articleId;
+        this.tagId = tagId;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getArticleId() {
+        return articleId;
+    }
+
+    public void setArticleId(Long articleId) {
+        this.articleId = articleId;
+    }
+
+    public Long getTagId() {
+        return tagId;
+    }
+
+    public void setTagId(Long tagId) {
+        this.tagId = tagId;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Comment.java
+++ b/TARGET/src/main/java/realworld/com/model/Comment.java
@@ -1,0 +1,111 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import java.time.Instant;
+
+@Entity
+@Table(name = "comments")
+public class Comment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(columnDefinition = "TEXT")
+    private String body;
+
+    @Column(name = "article_id")
+    private Long articleId;
+
+    @Column(name = "author_id")
+    private Long authorId;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    // Default constructor required by JPA
+    public Comment() {
+    }
+
+    public Comment(Long id, String body, Long articleId, Long authorId, Instant createdAt, Instant updatedAt) {
+        this.id = id;
+        this.body = body;
+        this.articleId = articleId;
+        this.authorId = authorId;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // Factory method to create a new comment
+    public static Comment create(String body, Long articleId, Long authorId) {
+        Comment comment = new Comment();
+        comment.setBody(body);
+        comment.setArticleId(articleId);
+        comment.setAuthorId(authorId);
+        return comment;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = Instant.now();
+        updatedAt = Instant.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public Long getArticleId() {
+        return articleId;
+    }
+
+    public void setArticleId(Long articleId) {
+        this.articleId = articleId;
+    }
+
+    public Long getAuthorId() {
+        return authorId;
+    }
+
+    public void setAuthorId(Long authorId) {
+        this.authorId = authorId;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Favorite.java
+++ b/TARGET/src/main/java/realworld/com/model/Favorite.java
@@ -1,0 +1,69 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "favorite")
+public class Favorite {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "favorited_id")
+    private Long favoritedId;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    // Default constructor required by JPA
+    public Favorite() {
+    }
+
+    public Favorite(Long id, Long userId, Long favoritedId) {
+        this.id = id;
+        this.userId = userId;
+        this.favoritedId = favoritedId;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = Instant.now();
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Long getFavoritedId() {
+        return favoritedId;
+    }
+
+    public void setFavoritedId(Long favoritedId) {
+        this.favoritedId = favoritedId;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Profile.java
+++ b/TARGET/src/main/java/realworld/com/model/Profile.java
@@ -1,0 +1,66 @@
+package realworld.com.model;
+
+/**
+ * Profile is a DTO class representing a user profile.
+ * It's not an entity as it's derived from User entity with additional following status.
+ */
+public class Profile {
+    private String username;
+    private String bio;
+    private String image;
+    private boolean following;
+
+    // Default constructor
+    public Profile() {
+    }
+
+    public Profile(String username, String bio, String image, boolean following) {
+        this.username = username;
+        this.bio = bio;
+        this.image = image;
+        this.following = following;
+    }
+
+    // Factory method to create a profile from a user
+    public static Profile fromUser(User user, boolean following) {
+        return new Profile(
+            user.getUsername(),
+            user.getBio(),
+            user.getImage(),
+            following
+        );
+    }
+
+    // Getters and Setters
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public void setBio(String bio) {
+        this.bio = bio;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public boolean isFollowing() {
+        return following;
+    }
+
+    public void setFollowing(boolean following) {
+        this.following = following;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/Tag.java
+++ b/TARGET/src/main/java/realworld/com/model/Tag.java
@@ -1,0 +1,62 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "tags")
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Column(unique = true)
+    private String name;
+
+    @ManyToMany(mappedBy = "tags")
+    private Set<Article> articles = new HashSet<>();
+
+    // Default constructor required by JPA
+    public Tag() {
+    }
+
+    public Tag(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    // Factory method to create a new tag
+    public static Tag create(String tagName) {
+        Tag tag = new Tag();
+        tag.setName(tagName);
+        return tag;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<Article> getArticles() {
+        return articles;
+    }
+
+    public void setArticles(Set<Article> articles) {
+        this.articles = articles;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/User.java
+++ b/TARGET/src/main/java/realworld/com/model/User.java
@@ -1,0 +1,125 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import java.time.Instant;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "Username cannot be empty")
+    @Column(unique = true)
+    private String username;
+
+    @NotBlank(message = "Password cannot be empty")
+    private String password;
+
+    @NotBlank(message = "Email cannot be empty")
+    @Column(unique = true)
+    private String email;
+
+    private String bio;
+
+    private String image;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    // Default constructor required by JPA
+    public User() {
+    }
+
+    public User(Long id, String username, String password, String email, String bio, String image, Instant createdAt, Instant updatedAt) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.bio = bio;
+        this.image = image;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = Instant.now();
+        updatedAt = Instant.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public void setBio(String bio) {
+        this.bio = bio;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/UserFollower.java
+++ b/TARGET/src/main/java/realworld/com/model/UserFollower.java
@@ -1,0 +1,69 @@
+package realworld.com.model;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "followers")
+public class UserFollower {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "followee_id")
+    private Long followeeId;
+
+    @Column(name = "inserted_at")
+    private Instant insertedAt;
+
+    // Default constructor required by JPA
+    public UserFollower() {
+    }
+
+    public UserFollower(Long userId, Long followeeId, Instant insertedAt) {
+        this.userId = userId;
+        this.followeeId = followeeId;
+        this.insertedAt = insertedAt;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        insertedAt = Instant.now();
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Long getFolloweeId() {
+        return followeeId;
+    }
+
+    public void setFolloweeId(Long followeeId) {
+        this.followeeId = followeeId;
+    }
+
+    public Instant getInsertedAt() {
+        return insertedAt;
+    }
+
+    public void setInsertedAt(Instant insertedAt) {
+        this.insertedAt = insertedAt;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/dto/ArticleForResponse.java
+++ b/TARGET/src/main/java/realworld/com/model/dto/ArticleForResponse.java
@@ -1,0 +1,129 @@
+package realworld.com.model.dto;
+
+import realworld.com.model.Profile;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * DTO for article responses in the API
+ */
+public class ArticleForResponse {
+    private String slug;
+    private String title;
+    private String description;
+    private String body;
+    private List<String> tagList = new ArrayList<>();
+    private String createdAt;
+    private String updatedAt;
+    private boolean favorited;
+    private int favoritesCount;
+    private Profile author;
+
+    // Default constructor
+    public ArticleForResponse() {
+    }
+
+    public ArticleForResponse(String slug, String title, String description, String body, 
+                             List<String> tagList, String createdAt, String updatedAt, 
+                             boolean favorited, int favoritesCount, Profile author) {
+        this.slug = slug;
+        this.title = title;
+        this.description = description;
+        this.body = body;
+        this.tagList = tagList;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.favorited = favorited;
+        this.favoritesCount = favoritesCount;
+        this.author = author;
+    }
+
+    // Helper method to format Instant to ISO-8601 string
+    public static String formatInstant(Instant instant) {
+        return DateTimeFormatter.ISO_INSTANT.format(instant);
+    }
+
+    // Getters and Setters
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public List<String> getTagList() {
+        return tagList;
+    }
+
+    public void setTagList(List<String> tagList) {
+        this.tagList = tagList;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(String updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public boolean isFavorited() {
+        return favorited;
+    }
+
+    public void setFavorited(boolean favorited) {
+        this.favorited = favorited;
+    }
+
+    public int getFavoritesCount() {
+        return favoritesCount;
+    }
+
+    public void setFavoritesCount(int favoritesCount) {
+        this.favoritesCount = favoritesCount;
+    }
+
+    public Profile getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(Profile author) {
+        this.author = author;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/dto/ArticlePosted.java
+++ b/TARGET/src/main/java/realworld/com/model/dto/ArticlePosted.java
@@ -1,0 +1,81 @@
+package realworld.com.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import realworld.com.model.Article;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * DTO for creating a new article
+ */
+public class ArticlePosted {
+    @NotBlank(message = "Title cannot be empty")
+    private String title;
+
+    @NotBlank(message = "Description cannot be empty")
+    private String description;
+
+    @NotBlank(message = "Body cannot be empty")
+    private String body;
+
+    private List<String> tagList = new ArrayList<>();
+
+    // Default constructor
+    public ArticlePosted() {
+    }
+
+    public ArticlePosted(String title, String description, String body, List<String> tagList) {
+        this.title = title;
+        this.description = description;
+        this.body = body;
+        this.tagList = tagList;
+    }
+
+    // Factory method to create an Article entity
+    public Article toArticle(Long authorId) {
+        Article article = new Article();
+        article.setSlug(Article.slugify(title));
+        article.setTitle(title);
+        article.setDescription(description);
+        article.setBody(body);
+        article.setAuthorId(authorId);
+        article.setCreatedAt(Instant.now());
+        article.setUpdatedAt(Instant.now());
+        return article;
+    }
+
+    // Getters and Setters
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public List<String> getTagList() {
+        return tagList;
+    }
+
+    public void setTagList(List<String> tagList) {
+        this.tagList = tagList;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/dto/ArticleRequest.java
+++ b/TARGET/src/main/java/realworld/com/model/dto/ArticleRequest.java
@@ -1,0 +1,65 @@
+package realworld.com.model.dto;
+
+/**
+ * DTO for article search/filtering requests
+ */
+public class ArticleRequest {
+    private String tag;
+    private String authorName;
+    private String favorited;
+    private Integer limit;
+    private Integer offset;
+
+    // Default constructor
+    public ArticleRequest() {
+    }
+
+    public ArticleRequest(String tag, String authorName, String favorited, Integer limit, Integer offset) {
+        this.tag = tag;
+        this.authorName = authorName;
+        this.favorited = favorited;
+        this.limit = limit;
+        this.offset = offset;
+    }
+
+    // Getters and Setters
+    public String getTag() {
+        return tag;
+    }
+
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    public String getAuthorName() {
+        return authorName;
+    }
+
+    public void setAuthorName(String authorName) {
+        this.authorName = authorName;
+    }
+
+    public String getFavorited() {
+        return favorited;
+    }
+
+    public void setFavorited(String favorited) {
+        this.favorited = favorited;
+    }
+
+    public Integer getLimit() {
+        return limit;
+    }
+
+    public void setLimit(Integer limit) {
+        this.limit = limit;
+    }
+
+    public Integer getOffset() {
+        return offset;
+    }
+
+    public void setOffset(Integer offset) {
+        this.offset = offset;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/dto/ArticleUpdated.java
+++ b/TARGET/src/main/java/realworld/com/model/dto/ArticleUpdated.java
@@ -1,0 +1,65 @@
+package realworld.com.model.dto;
+
+import realworld.com.model.Article;
+
+import java.time.Instant;
+
+/**
+ * DTO for updating an article
+ */
+public class ArticleUpdated {
+    private String title;
+    private String description;
+    private String body;
+
+    // Default constructor
+    public ArticleUpdated() {
+    }
+
+    public ArticleUpdated(String title, String description, String body) {
+        this.title = title;
+        this.description = description;
+        this.body = body;
+    }
+
+    // Method to apply updates to an existing article
+    public Article applyTo(Article article) {
+        if (title != null) {
+            article.setTitle(title);
+            article.setSlug(Article.slugify(title));
+        }
+        if (description != null) {
+            article.setDescription(description);
+        }
+        if (body != null) {
+            article.setBody(body);
+        }
+        article.setUpdatedAt(Instant.now());
+        return article;
+    }
+
+    // Getters and Setters
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/dto/AuthTokenContent.java
+++ b/TARGET/src/main/java/realworld/com/model/dto/AuthTokenContent.java
@@ -1,0 +1,25 @@
+package realworld.com.model.dto;
+
+/**
+ * DTO for JWT token content
+ */
+public class AuthTokenContent {
+    private Long userId;
+
+    // Default constructor
+    public AuthTokenContent() {
+    }
+
+    public AuthTokenContent(Long userId) {
+        this.userId = userId;
+    }
+
+    // Getters and Setters
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/dto/CommentData.java
+++ b/TARGET/src/main/java/realworld/com/model/dto/CommentData.java
@@ -1,0 +1,77 @@
+package realworld.com.model.dto;
+
+import realworld.com.model.Profile;
+
+/**
+ * DTO for comment responses in the API
+ */
+public class CommentData {
+    private Long id;
+    private String createdAt;
+    private String updatedAt;
+    private String body;
+    private String username;
+    private Profile author;
+
+    // Default constructor
+    public CommentData() {
+    }
+
+    public CommentData(Long id, String createdAt, String updatedAt, String body, String username, Profile author) {
+        this.id = id;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.body = body;
+        this.username = username;
+        this.author = author;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(String updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public Profile getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(Profile author) {
+        this.author = author;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/dto/CommentForJson.java
+++ b/TARGET/src/main/java/realworld/com/model/dto/CommentForJson.java
@@ -1,0 +1,28 @@
+package realworld.com.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * DTO for creating a new comment
+ */
+public class CommentForJson {
+    @NotBlank(message = "Comment body cannot be empty")
+    private String body;
+
+    // Default constructor
+    public CommentForJson() {
+    }
+
+    public CommentForJson(String body) {
+        this.body = body;
+    }
+
+    // Getters and Setters
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/dto/CommentRequest.java
+++ b/TARGET/src/main/java/realworld/com/model/dto/CommentRequest.java
@@ -1,0 +1,25 @@
+package realworld.com.model.dto;
+
+/**
+ * DTO for comment requests in the API
+ */
+public class CommentRequest {
+    private CommentForJson comment;
+
+    // Default constructor
+    public CommentRequest() {
+    }
+
+    public CommentRequest(CommentForJson comment) {
+        this.comment = comment;
+    }
+
+    // Getters and Setters
+    public CommentForJson getComment() {
+        return comment;
+    }
+
+    public void setComment(CommentForJson comment) {
+        this.comment = comment;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/dto/ResponseWrappers.java
+++ b/TARGET/src/main/java/realworld/com/model/dto/ResponseWrappers.java
@@ -1,0 +1,141 @@
+package realworld.com.model.dto;
+
+import realworld.com.model.Profile;
+
+import java.util.List;
+
+/**
+ * Response wrapper classes for API responses
+ */
+public class ResponseWrappers {
+
+    // User response wrapper
+    public static class ResponseUser {
+        private UserWithToken user;
+
+        public ResponseUser() {
+        }
+
+        public ResponseUser(UserWithToken user) {
+            this.user = user;
+        }
+
+        public UserWithToken getUser() {
+            return user;
+        }
+
+        public void setUser(UserWithToken user) {
+            this.user = user;
+        }
+    }
+
+    // Profile response wrapper
+    public static class ResponseProfile {
+        private Profile profile;
+
+        public ResponseProfile() {
+        }
+
+        public ResponseProfile(Profile profile) {
+            this.profile = profile;
+        }
+
+        public Profile getProfile() {
+            return profile;
+        }
+
+        public void setProfile(Profile profile) {
+            this.profile = profile;
+        }
+    }
+
+    // Article response wrapper
+    public static class ForResponseArticle {
+        private ArticleForResponse article;
+
+        public ForResponseArticle() {
+        }
+
+        public ForResponseArticle(ArticleForResponse article) {
+            this.article = article;
+        }
+
+        public ArticleForResponse getArticle() {
+            return article;
+        }
+
+        public void setArticle(ArticleForResponse article) {
+            this.article = article;
+        }
+    }
+
+    // Articles list response wrapper
+    public static class ForResponseArticles {
+        private List<ArticleForResponse> articles;
+        private int articlesCount;
+
+        public ForResponseArticles() {
+        }
+
+        public ForResponseArticles(List<ArticleForResponse> articles, int articlesCount) {
+            this.articles = articles;
+            this.articlesCount = articlesCount;
+        }
+
+        public List<ArticleForResponse> getArticles() {
+            return articles;
+        }
+
+        public void setArticles(List<ArticleForResponse> articles) {
+            this.articles = articles;
+        }
+
+        public int getArticlesCount() {
+            return articlesCount;
+        }
+
+        public void setArticlesCount(int articlesCount) {
+            this.articlesCount = articlesCount;
+        }
+    }
+
+    // Comment response wrapper
+    public static class CommentResponse {
+        private CommentData comment;
+
+        public CommentResponse() {
+        }
+
+        public CommentResponse(CommentData comment) {
+            this.comment = comment;
+        }
+
+        public CommentData getComment() {
+            return comment;
+        }
+
+        public void setComment(CommentData comment) {
+            this.comment = comment;
+        }
+    }
+
+    // Comments list response wrapper
+    public static class CommentsResponse {
+        private List<CommentData> comments;
+
+        public CommentsResponse() {
+        }
+
+        public CommentsResponse(List<CommentData> comments) {
+            this.comments = comments;
+        }
+
+        public List<CommentData> getComments() {
+            return comments;
+        }
+
+        public void setComments(List<CommentData> comments) {
+            this.comments = comments;
+        }
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/dto/UserRegistration.java
+++ b/TARGET/src/main/java/realworld/com/model/dto/UserRegistration.java
@@ -1,0 +1,69 @@
+package realworld.com.model.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import realworld.com.model.User;
+
+import java.time.Instant;
+
+/**
+ * DTO for user registration
+ */
+public class UserRegistration {
+    @NotBlank(message = "Username cannot be empty")
+    private String username;
+
+    @NotBlank(message = "Password cannot be empty")
+    private String password;
+
+    @NotBlank(message = "Email cannot be empty")
+    @Email(message = "Email should be valid")
+    private String email;
+
+    // Default constructor
+    public UserRegistration() {
+    }
+
+    public UserRegistration(String username, String password, String email) {
+        this.username = username;
+        this.password = password;
+        this.email = email;
+    }
+
+    // Factory method to create a User entity from registration data
+    public User toUser() {
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword(new BCryptPasswordEncoder().encode(password));
+        user.setEmail(email);
+        user.setCreatedAt(Instant.now());
+        user.setUpdatedAt(Instant.now());
+        return user;
+    }
+
+    // Getters and Setters
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/dto/UserUpdate.java
+++ b/TARGET/src/main/java/realworld/com/model/dto/UserUpdate.java
@@ -1,0 +1,91 @@
+package realworld.com.model.dto;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import realworld.com.model.User;
+
+import java.time.Instant;
+
+/**
+ * DTO for updating user information
+ */
+public class UserUpdate {
+    private String username;
+    private String password;
+    private String email;
+    private String bio;
+    private String image;
+
+    // Default constructor
+    public UserUpdate() {
+    }
+
+    public UserUpdate(String username, String password, String email, String bio, String image) {
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.bio = bio;
+        this.image = image;
+    }
+
+    // Method to apply updates to an existing user
+    public User applyTo(User user) {
+        if (username != null) {
+            user.setUsername(username);
+        }
+        if (password != null) {
+            user.setPassword(new BCryptPasswordEncoder().encode(password));
+        }
+        if (email != null) {
+            user.setEmail(email);
+        }
+        if (bio != null) {
+            user.setBio(bio);
+        }
+        if (image != null) {
+            user.setImage(image);
+        }
+        user.setUpdatedAt(Instant.now());
+        return user;
+    }
+
+    // Getters and Setters
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public void setBio(String bio) {
+        this.bio = bio;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/model/dto/UserWithToken.java
+++ b/TARGET/src/main/java/realworld/com/model/dto/UserWithToken.java
@@ -1,0 +1,65 @@
+package realworld.com.model.dto;
+
+/**
+ * DTO for returning user information with authentication token
+ */
+public class UserWithToken {
+    private String username;
+    private String email;
+    private String bio;
+    private String image;
+    private String token;
+
+    // Default constructor
+    public UserWithToken() {
+    }
+
+    public UserWithToken(String username, String email, String bio, String image, String token) {
+        this.username = username;
+        this.email = email;
+        this.bio = bio;
+        this.image = image;
+        this.token = token;
+    }
+
+    // Getters and Setters
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getBio() {
+        return bio;
+    }
+
+    public void setBio(String bio) {
+        this.bio = bio;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+}


### PR DESCRIPTION
This PR converts the Scala data models to Java JPA entities as part of the migration from Scala to Java.

Changes:
- Created Maven project structure with Spring Boot dependencies
- Converted all data models to JPA entities
- Organized DTOs in a separate package
- Used Java 17 features
- Added proper JPA annotations for database mapping
- Implemented proper relationships between entities
- Used Spring Security for password encoding

All models maintain the same functionality as the original Scala models but are now compatible with Spring Data JPA.