### PR TITLE
STJM-1: Migrate /tags endpoint from Scala to Java

### DIFF
--- a/TARGET/README.md
+++ b/TARGET/README.md
@@ -1,0 +1,37 @@
+# Tags API Migration
+
+This directory contains the Java implementation of the `/api/tags` endpoint, migrated from Scala/Akka to Java/Spring Boot.
+
+## Implementation Details
+
+The implementation follows the Spring Boot architecture with the following components:
+
+- **Model**: `Tag.java` - JPA entity representing a tag in the database
+- **Repository**: `TagRepository.java` - Spring Data JPA repository for database operations
+- **Service**: `TagService.java` - Business logic layer
+- **Controller**: `TagController.java` - REST API endpoint
+- **DTO**: `TagsResponse.java` - Data Transfer Object for API responses
+
+## API Endpoint
+
+The API provides the following endpoint:
+
+- `GET /api/tags` - Returns a list of all tags in the system
+
+## Running the Application
+
+To run the application:
+
+```bash
+mvn spring-boot:run
+```
+
+## Testing
+
+The implementation includes unit tests for both the service and controller layers.
+
+## Migration Notes
+
+- The original Scala implementation used Slick for database access, which has been replaced with Spring Data JPA
+- The original Akka HTTP routes have been replaced with Spring MVC controllers
+- The response format remains the same, ensuring API compatibility

--- a/TARGET/pom.xml
+++ b/TARGET/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>realworld.com</groupId>
+    <artifactId>realworld-spring</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>realworld-spring</name>
+    <description>Real World Spring Boot Implementation</description>
+    
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>3.5.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/TARGET/src/main/java/realworld/com/RealWorldApplication.java
+++ b/TARGET/src/main/java/realworld/com/RealWorldApplication.java
@@ -1,0 +1,12 @@
+package realworld.com;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class RealWorldApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(RealWorldApplication.class, args);
+    }
+}

--- a/TARGET/src/main/java/realworld/com/tags/controller/TagController.java
+++ b/TARGET/src/main/java/realworld/com/tags/controller/TagController.java
@@ -1,0 +1,31 @@
+package realworld.com.tags.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import realworld.com.tags.dto.TagsResponse;
+import realworld.com.tags.service.TagService;
+
+@RestController
+@RequestMapping("/api/tags")
+public class TagController {
+
+    private final TagService tagService;
+
+    @Autowired
+    public TagController(TagService tagService) {
+        this.tagService = tagService;
+    }
+
+    /**
+     * GET /api/tags
+     * Returns a list of all tags in the system
+     */
+    @GetMapping
+    public ResponseEntity<TagsResponse> getTags() {
+        TagsResponse response = tagService.getAllTags();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/TARGET/src/main/java/realworld/com/tags/dto/TagsResponse.java
+++ b/TARGET/src/main/java/realworld/com/tags/dto/TagsResponse.java
@@ -1,0 +1,25 @@
+package realworld.com.tags.dto;
+
+import java.util.List;
+
+/**
+ * DTO for the tags response, equivalent to the Scala ResponseTags case class
+ */
+public class TagsResponse {
+    private List<String> tags;
+
+    public TagsResponse() {
+    }
+
+    public TagsResponse(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+}

--- a/TARGET/src/main/java/realworld/com/tags/model/Tag.java
+++ b/TARGET/src/main/java/realworld/com/tags/model/Tag.java
@@ -1,0 +1,71 @@
+package realworld.com.tags.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "tags")
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, unique = true)
+    private String name;
+
+    // Default constructor required by JPA
+    public Tag() {
+    }
+
+    public Tag(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    // Static factory method similar to the Scala TagV.create
+    public static Tag create(String tagName) {
+        return new Tag(null, tagName);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Tag tag = (Tag) o;
+
+        if (id != null ? !id.equals(tag.id) : tag.id != null) return false;
+        return name != null ? name.equals(tag.name) : tag.name == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = id != null ? id.hashCode() : 0;
+        result = 31 * result + (name != null ? name.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Tag{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/TARGET/src/main/java/realworld/com/tags/repository/TagRepository.java
+++ b/TARGET/src/main/java/realworld/com/tags/repository/TagRepository.java
@@ -1,0 +1,22 @@
+package realworld.com.tags.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import realworld.com.tags.model.Tag;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    
+    /**
+     * Find a tag by its name
+     */
+    Optional<Tag> findByName(String name);
+    
+    /**
+     * Find tags by a list of names
+     */
+    List<Tag> findByNameIn(List<String> names);
+}

--- a/TARGET/src/main/java/realworld/com/tags/service/TagService.java
+++ b/TARGET/src/main/java/realworld/com/tags/service/TagService.java
@@ -1,0 +1,34 @@
+package realworld.com.tags.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import realworld.com.tags.dto.TagsResponse;
+import realworld.com.tags.model.Tag;
+import realworld.com.tags.repository.TagRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    @Autowired
+    public TagService(TagRepository tagRepository) {
+        this.tagRepository = tagRepository;
+    }
+
+    /**
+     * Get all tags in the system
+     * @return TagsResponse containing a list of tag names
+     */
+    public TagsResponse getAllTags() {
+        List<String> tagNames = tagRepository.findAll()
+                .stream()
+                .map(Tag::getName)
+                .collect(Collectors.toList());
+        
+        return new TagsResponse(tagNames);
+    }
+}

--- a/TARGET/src/main/resources/application.properties
+++ b/TARGET/src/main/resources/application.properties
@@ -1,0 +1,14 @@
+# Database Configuration
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# JPA Configuration
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# Server Configuration
+server.port=8080

--- a/TARGET/src/test/java/realworld/com/tags/controller/TagControllerTest.java
+++ b/TARGET/src/test/java/realworld/com/tags/controller/TagControllerTest.java
@@ -1,0 +1,43 @@
+package realworld.com.tags.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import realworld.com.tags.dto.TagsResponse;
+import realworld.com.tags.service.TagService;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(TagController.class)
+public class TagControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TagService tagService;
+
+    @Test
+    public void testGetTags() throws Exception {
+        // Arrange
+        TagsResponse response = new TagsResponse(Arrays.asList("java", "spring", "test"));
+        when(tagService.getAllTags()).thenReturn(response);
+
+        // Act & Assert
+        mockMvc.perform(get("/api/tags")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.tags").isArray())
+                .andExpect(jsonPath("$.tags[0]").value("java"))
+                .andExpect(jsonPath("$.tags[1]").value("spring"))
+                .andExpect(jsonPath("$.tags[2]").value("test"));
+    }
+}

--- a/TARGET/src/test/java/realworld/com/tags/service/TagServiceTest.java
+++ b/TARGET/src/test/java/realworld/com/tags/service/TagServiceTest.java
@@ -1,0 +1,49 @@
+package realworld.com.tags.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import realworld.com.tags.dto.TagsResponse;
+import realworld.com.tags.model.Tag;
+import realworld.com.tags.repository.TagRepository;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TagServiceTest {
+
+    @Mock
+    private TagRepository tagRepository;
+
+    @InjectMocks
+    private TagService tagService;
+
+    @Test
+    public void testGetAllTags() {
+        // Arrange
+        List<Tag> tags = Arrays.asList(
+                new Tag(1L, "java"),
+                new Tag(2L, "spring"),
+                new Tag(3L, "test")
+        );
+        when(tagRepository.findAll()).thenReturn(tags);
+
+        // Act
+        TagsResponse response = tagService.getAllTags();
+
+        // Assert
+        assertNotNull(response);
+        assertNotNull(response.getTags());
+        assertEquals(3, response.getTags().size());
+        assertEquals("java", response.getTags().get(0));
+        assertEquals("spring", response.getTags().get(1));
+        assertEquals("test", response.getTags().get(2));
+    }
+}


### PR DESCRIPTION
## Description
This PR implements STJM-1, migrating the `/tags` endpoint from Scala/Akka to Java/Spring Boot.

## Changes
- Created Java equivalent of the `/tags` endpoint using Spring Boot 3.5.0
- Implemented the Tag entity with JPA annotations
- Created Spring Data JPA repository for database access
- Implemented service layer for business logic
- Created REST controller for the API endpoint
- Added unit tests for both service and controller
- Added Maven configuration for the project

## Testing
- Unit tests have been added for both the service and controller layers
- The API contract remains the same, returning a list of tags in the same format as the original implementation

## Notes
- All new code is placed in the TARGET directory as required
- The implementation uses Spring Boot, Spring MVC, and Spring Data JPA
- No Scala/Akka dependencies are used in the new implementation