### PR TITLE
STJM-3: Migrate Tags Module from Scala to Java

### DIFF
--- a/TARGET/pom.xml
+++ b/TARGET/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.5.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <groupId>realworld.com</groupId>
+    <artifactId>realworld-app</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>realworld-app</name>
+    <description>Realworld application migrated from Scala to Java</description>
+    
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>3.5.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/TARGET/src/main/java/realworld/com/RealWorldApplication.java
+++ b/TARGET/src/main/java/realworld/com/RealWorldApplication.java
@@ -1,0 +1,12 @@
+package realworld.com;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class RealWorldApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(RealWorldApplication.class, args);
+    }
+}

--- a/TARGET/src/main/java/realworld/com/articles/ArticleTag.java
+++ b/TARGET/src/main/java/realworld/com/articles/ArticleTag.java
@@ -1,0 +1,109 @@
+package realworld.com.articles;
+
+import java.util.Objects;
+
+/**
+ * Represents a relationship between an article and a tag.
+ */
+public class ArticleTag {
+    private Long id;
+    private Long articleId;
+    private Long tagId;
+
+    /**
+     * Default constructor required by JPA
+     */
+    public ArticleTag() {
+    }
+
+    /**
+     * Constructor with all fields
+     * 
+     * @param id        the relationship ID
+     * @param articleId the article ID
+     * @param tagId     the tag ID
+     */
+    public ArticleTag(Long id, Long articleId, Long tagId) {
+        this.id = id;
+        this.articleId = articleId;
+        this.tagId = tagId;
+    }
+
+    /**
+     * Gets the relationship ID
+     * 
+     * @return the relationship ID
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Sets the relationship ID
+     * 
+     * @param id the relationship ID
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the article ID
+     * 
+     * @return the article ID
+     */
+    public Long getArticleId() {
+        return articleId;
+    }
+
+    /**
+     * Sets the article ID
+     * 
+     * @param articleId the article ID
+     */
+    public void setArticleId(Long articleId) {
+        this.articleId = articleId;
+    }
+
+    /**
+     * Gets the tag ID
+     * 
+     * @return the tag ID
+     */
+    public Long getTagId() {
+        return tagId;
+    }
+
+    /**
+     * Sets the tag ID
+     * 
+     * @param tagId the tag ID
+     */
+    public void setTagId(Long tagId) {
+        this.tagId = tagId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ArticleTag that = (ArticleTag) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(articleId, that.articleId) &&
+                Objects.equals(tagId, that.tagId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, articleId, tagId);
+    }
+
+    @Override
+    public String toString() {
+        return "ArticleTag{" +
+                "id=" + id +
+                ", articleId=" + articleId +
+                ", tagId=" + tagId +
+                '}';
+    }
+}

--- a/TARGET/src/main/java/realworld/com/articles/ArticleTagEntity.java
+++ b/TARGET/src/main/java/realworld/com/articles/ArticleTagEntity.java
@@ -1,0 +1,153 @@
+package realworld.com.articles;
+
+import jakarta.persistence.*;
+import java.util.Objects;
+
+/**
+ * JPA Entity for articles_tags table.
+ */
+@Entity
+@Table(name = "articles_tags")
+public class ArticleTagEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "article_id", nullable = false)
+    private Long articleId;
+    
+    @Column(name = "tag_id", nullable = false)
+    private Long tagId;
+
+    /**
+     * Default constructor required by JPA
+     */
+    public ArticleTagEntity() {
+    }
+
+    /**
+     * Constructor with articleId and tagId
+     * 
+     * @param articleId the article ID
+     * @param tagId     the tag ID
+     */
+    public ArticleTagEntity(Long articleId, Long tagId) {
+        this.articleId = articleId;
+        this.tagId = tagId;
+    }
+
+    /**
+     * Constructor with all fields
+     * 
+     * @param id        the relationship ID
+     * @param articleId the article ID
+     * @param tagId     the tag ID
+     */
+    public ArticleTagEntity(Long id, Long articleId, Long tagId) {
+        this.id = id;
+        this.articleId = articleId;
+        this.tagId = tagId;
+    }
+
+    /**
+     * Gets the relationship ID
+     * 
+     * @return the relationship ID
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Sets the relationship ID
+     * 
+     * @param id the relationship ID
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the article ID
+     * 
+     * @return the article ID
+     */
+    public Long getArticleId() {
+        return articleId;
+    }
+
+    /**
+     * Sets the article ID
+     * 
+     * @param articleId the article ID
+     */
+    public void setArticleId(Long articleId) {
+        this.articleId = articleId;
+    }
+
+    /**
+     * Gets the tag ID
+     * 
+     * @return the tag ID
+     */
+    public Long getTagId() {
+        return tagId;
+    }
+
+    /**
+     * Sets the tag ID
+     * 
+     * @param tagId the tag ID
+     */
+    public void setTagId(Long tagId) {
+        this.tagId = tagId;
+    }
+
+    /**
+     * Converts this entity to an ArticleTag model
+     * 
+     * @return an ArticleTag instance
+     */
+    public ArticleTag toArticleTag() {
+        return new ArticleTag(id, articleId, tagId);
+    }
+
+    /**
+     * Creates an ArticleTagEntity from an ArticleTag model
+     * 
+     * @param articleTag the ArticleTag model
+     * @return an ArticleTagEntity instance
+     */
+    public static ArticleTagEntity fromArticleTag(ArticleTag articleTag) {
+        return new ArticleTagEntity(
+                articleTag.getId(),
+                articleTag.getArticleId(),
+                articleTag.getTagId()
+        );
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ArticleTagEntity that = (ArticleTagEntity) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(articleId, that.articleId) &&
+                Objects.equals(tagId, that.tagId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, articleId, tagId);
+    }
+
+    @Override
+    public String toString() {
+        return "ArticleTagEntity{" +
+                "id=" + id +
+                ", articleId=" + articleId +
+                ", tagId=" + tagId +
+                '}';
+    }
+}

--- a/TARGET/src/main/java/realworld/com/articles/ArticleTagRepository.java
+++ b/TARGET/src/main/java/realworld/com/articles/ArticleTagRepository.java
@@ -1,0 +1,50 @@
+package realworld.com.articles;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Spring Data JPA repository for ArticleTagEntity.
+ */
+@Repository
+public interface ArticleTagRepository extends JpaRepository<ArticleTagEntity, Long> {
+    
+    /**
+     * Find all article-tag relationships for a specific article
+     * 
+     * @param articleId the article ID
+     * @return list of article-tag relationships
+     */
+    List<ArticleTagEntity> findByArticleId(Long articleId);
+    
+    /**
+     * Find all article-tag relationships for a collection of articles
+     * 
+     * @param articleIds collection of article IDs
+     * @return list of article-tag relationships
+     */
+    List<ArticleTagEntity> findByArticleIdIn(Collection<Long> articleIds);
+    
+    /**
+     * Custom query to join article tags with tag information
+     * 
+     * @param articleId the article ID
+     * @return list of tags for the article
+     */
+    @Query("SELECT t FROM TagEntity t JOIN ArticleTagEntity at ON t.id = at.tagId WHERE at.articleId = :articleId")
+    List<TagEntity> findTagsByArticleId(@Param("articleId") Long articleId);
+    
+    /**
+     * Custom query to join article tags with tag information for multiple articles
+     * 
+     * @param articleIds collection of article IDs
+     * @return list of article IDs and their associated tags
+     */
+    @Query("SELECT at.articleId, t FROM TagEntity t JOIN ArticleTagEntity at ON t.id = at.tagId WHERE at.articleId IN :articleIds")
+    List<Object[]> findTagsByArticleIdIn(@Param("articleIds") Collection<Long> articleIds);
+}

--- a/TARGET/src/main/java/realworld/com/articles/TagEntity.java
+++ b/TARGET/src/main/java/realworld/com/articles/TagEntity.java
@@ -1,0 +1,121 @@
+package realworld.com.articles;
+
+import jakarta.persistence.*;
+import java.util.Objects;
+
+/**
+ * JPA Entity for tags table.
+ */
+@Entity
+@Table(name = "tags")
+public class TagEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "name", nullable = false, unique = true)
+    private String name;
+
+    /**
+     * Default constructor required by JPA
+     */
+    public TagEntity() {
+    }
+
+    /**
+     * Constructor with name
+     * 
+     * @param name the tag name
+     */
+    public TagEntity(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Constructor with all fields
+     * 
+     * @param id   the tag ID
+     * @param name the tag name
+     */
+    public TagEntity(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    /**
+     * Gets the tag ID
+     * 
+     * @return the tag ID
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Sets the tag ID
+     * 
+     * @param id the tag ID
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the tag name
+     * 
+     * @return the tag name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the tag name
+     * 
+     * @param name the tag name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Converts this entity to a TagV model
+     * 
+     * @return a TagV instance
+     */
+    public TagV toTagV() {
+        return new TagV(id, name);
+    }
+
+    /**
+     * Creates a TagEntity from a TagV model
+     * 
+     * @param tagV the TagV model
+     * @return a TagEntity instance
+     */
+    public static TagEntity fromTagV(TagV tagV) {
+        return new TagEntity(tagV.getId(), tagV.getName());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TagEntity tagEntity = (TagEntity) o;
+        return Objects.equals(id, tagEntity.id) && Objects.equals(name, tagEntity.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        return "TagEntity{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/TARGET/src/main/java/realworld/com/articles/TagRepository.java
+++ b/TARGET/src/main/java/realworld/com/articles/TagRepository.java
@@ -1,0 +1,22 @@
+package realworld.com.articles;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Spring Data JPA repository for TagEntity.
+ */
+@Repository
+public interface TagRepository extends JpaRepository<TagEntity, Long> {
+    
+    /**
+     * Find tags by their names
+     * 
+     * @param names collection of tag names
+     * @return list of matching tags
+     */
+    List<TagEntity> findByNameIn(Collection<String> names);
+}

--- a/TARGET/src/main/java/realworld/com/articles/TagV.java
+++ b/TARGET/src/main/java/realworld/com/articles/TagV.java
@@ -1,0 +1,95 @@
+package realworld.com.articles;
+
+import java.util.Objects;
+
+/**
+ * Represents a tag in the system.
+ */
+public class TagV {
+    private Long id;
+    private String name;
+
+    /**
+     * Default constructor required by JPA
+     */
+    public TagV() {
+    }
+
+    /**
+     * Constructor with all fields
+     * 
+     * @param id   the tag ID
+     * @param name the tag name
+     */
+    public TagV(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    /**
+     * Creates a new tag with the given name and a placeholder ID
+     * 
+     * @param tagName the name of the tag
+     * @return a new TagV instance
+     */
+    public static TagV create(String tagName) {
+        return new TagV(-1L, tagName);
+    }
+
+    /**
+     * Gets the tag ID
+     * 
+     * @return the tag ID
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Sets the tag ID
+     * 
+     * @param id the tag ID
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the tag name
+     * 
+     * @return the tag name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the tag name
+     * 
+     * @param name the tag name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TagV tagV = (TagV) o;
+        return Objects.equals(id, tagV.id) && Objects.equals(name, tagV.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        return "TagV{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                '}';
+    }
+}

--- a/TARGET/src/main/java/realworld/com/tags/JdbcTagStorage.java
+++ b/TARGET/src/main/java/realworld/com/tags/JdbcTagStorage.java
@@ -1,0 +1,92 @@
+package realworld.com.tags;
+
+import org.springframework.stereotype.Repository;
+import realworld.com.articles.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of TagStorage using Spring Data JPA repositories.
+ */
+@Repository
+public class JdbcTagStorage implements TagStorage {
+    
+    private final TagRepository tagRepository;
+    private final ArticleTagRepository articleTagRepository;
+    
+    /**
+     * Constructor with repositories
+     * 
+     * @param tagRepository        repository for tags
+     * @param articleTagRepository repository for article-tag relationships
+     */
+    public JdbcTagStorage(TagRepository tagRepository, ArticleTagRepository articleTagRepository) {
+        this.tagRepository = tagRepository;
+        this.articleTagRepository = articleTagRepository;
+    }
+    
+    @Override
+    public CompletableFuture<List<TagV>> getTags() {
+        return CompletableFuture.supplyAsync(() -> 
+            tagRepository.findAll().stream()
+                .map(TagEntity::toTagV)
+                .collect(Collectors.toList())
+        );
+    }
+    
+    @Override
+    public CompletableFuture<List<ArticleTagPair>> getTagsByArticles(List<Long> articleIds) {
+        return CompletableFuture.supplyAsync(() -> {
+            List<Object[]> results = articleTagRepository.findTagsByArticleIdIn(articleIds);
+            List<ArticleTagPair> pairs = new ArrayList<>();
+            
+            for (Object[] result : results) {
+                Long articleId = (Long) result[0];
+                TagEntity tagEntity = (TagEntity) result[1];
+                pairs.add(new ArticleTagPair(articleId, tagEntity.toTagV()));
+            }
+            
+            return pairs;
+        });
+    }
+    
+    @Override
+    public CompletableFuture<List<TagV>> getTagsByArticle(Long articleId) {
+        return CompletableFuture.supplyAsync(() -> 
+            articleTagRepository.findTagsByArticleId(articleId).stream()
+                .map(TagEntity::toTagV)
+                .collect(Collectors.toList())
+        );
+    }
+    
+    @Override
+    public CompletableFuture<List<TagV>> findTagByNames(List<String> tagNames) {
+        return CompletableFuture.supplyAsync(() -> 
+            tagRepository.findByNameIn(tagNames).stream()
+                .map(TagEntity::toTagV)
+                .collect(Collectors.toList())
+        );
+    }
+    
+    @Override
+    public CompletableFuture<List<TagV>> insertAndGet(List<TagV> tagVs) {
+        return CompletableFuture.supplyAsync(() -> {
+            // Convert TagV to TagEntity
+            List<TagEntity> entities = tagVs.stream()
+                .map(tagV -> new TagEntity(tagV.getName()))
+                .collect(Collectors.toList());
+            
+            // Save all entities
+            List<TagEntity> savedEntities = tagRepository.saveAll(entities);
+            
+            // Convert back to TagV
+            return savedEntities.stream()
+                .map(TagEntity::toTagV)
+                .collect(Collectors.toList());
+        });
+    }
+}

--- a/TARGET/src/main/java/realworld/com/tags/ResponseTags.java
+++ b/TARGET/src/main/java/realworld/com/tags/ResponseTags.java
@@ -1,0 +1,66 @@
+package realworld.com.tags;
+
+import realworld.com.articles.TagV;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Response object for tags endpoint.
+ */
+public class ResponseTags {
+    private List<TagV> tags;
+
+    /**
+     * Default constructor required for serialization
+     */
+    public ResponseTags() {
+    }
+
+    /**
+     * Constructor with tags list
+     * 
+     * @param tags list of tags
+     */
+    public ResponseTags(List<TagV> tags) {
+        this.tags = tags;
+    }
+
+    /**
+     * Gets the list of tags
+     * 
+     * @return list of tags
+     */
+    public List<TagV> getTags() {
+        return tags;
+    }
+
+    /**
+     * Sets the list of tags
+     * 
+     * @param tags list of tags
+     */
+    public void setTags(List<TagV> tags) {
+        this.tags = tags;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ResponseTags that = (ResponseTags) o;
+        return Objects.equals(tags, that.tags);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tags);
+    }
+
+    @Override
+    public String toString() {
+        return "ResponseTags{" +
+                "tags=" + tags +
+                '}';
+    }
+}

--- a/TARGET/src/main/java/realworld/com/tags/TagController.java
+++ b/TARGET/src/main/java/realworld/com/tags/TagController.java
@@ -1,0 +1,38 @@
+package realworld.com.tags;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * REST controller for tag-related endpoints.
+ */
+@RestController
+@RequestMapping("/tags")
+public class TagController {
+    
+    private final TagService tagService;
+    
+    /**
+     * Constructor with tag service
+     * 
+     * @param tagService service for tag operations
+     */
+    public TagController(TagService tagService) {
+        this.tagService = tagService;
+    }
+    
+    /**
+     * Get all tags
+     * 
+     * @return CompletableFuture with ResponseEntity containing all tags
+     */
+    @GetMapping
+    public CompletableFuture<ResponseEntity<ResponseTags>> getTags() {
+        return tagService.getTags()
+                .thenApply(ResponseEntity::ok);
+    }
+}

--- a/TARGET/src/main/java/realworld/com/tags/TagService.java
+++ b/TARGET/src/main/java/realworld/com/tags/TagService.java
@@ -1,0 +1,33 @@
+package realworld.com.tags;
+
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Service for tag-related operations.
+ */
+@Service
+public class TagService {
+    
+    private final TagStorage tagStorage;
+    
+    /**
+     * Constructor with tag storage
+     * 
+     * @param tagStorage storage for tag operations
+     */
+    public TagService(TagStorage tagStorage) {
+        this.tagStorage = tagStorage;
+    }
+    
+    /**
+     * Get all tags
+     * 
+     * @return CompletableFuture with ResponseTags containing all tags
+     */
+    public CompletableFuture<ResponseTags> getTags() {
+        return tagStorage.getTags()
+                .thenApply(tags -> new ResponseTags(tags));
+    }
+}

--- a/TARGET/src/main/java/realworld/com/tags/TagStorage.java
+++ b/TARGET/src/main/java/realworld/com/tags/TagStorage.java
@@ -1,0 +1,72 @@
+package realworld.com.tags;
+
+import realworld.com.articles.TagV;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Interface for tag storage operations.
+ */
+public interface TagStorage {
+    
+    /**
+     * Get all tags
+     * 
+     * @return CompletableFuture with a list of all tags
+     */
+    CompletableFuture<List<TagV>> getTags();
+    
+    /**
+     * Get tags for multiple articles
+     * 
+     * @param articleIds list of article IDs
+     * @return CompletableFuture with a list of article ID and tag pairs
+     */
+    CompletableFuture<List<ArticleTagPair>> getTagsByArticles(List<Long> articleIds);
+    
+    /**
+     * Get tags for a specific article
+     * 
+     * @param articleId the article ID
+     * @return CompletableFuture with a list of tags for the article
+     */
+    CompletableFuture<List<TagV>> getTagsByArticle(Long articleId);
+    
+    /**
+     * Find tags by their names
+     * 
+     * @param tagNames list of tag names
+     * @return CompletableFuture with a list of matching tags
+     */
+    CompletableFuture<List<TagV>> findTagByNames(List<String> tagNames);
+    
+    /**
+     * Insert tags and return the inserted tags with their IDs
+     * 
+     * @param tagVs list of tags to insert
+     * @return CompletableFuture with a list of inserted tags
+     */
+    CompletableFuture<List<TagV>> insertAndGet(List<TagV> tagVs);
+    
+    /**
+     * Class to represent an article ID and tag pair
+     */
+    class ArticleTagPair {
+        private final Long articleId;
+        private final TagV tag;
+        
+        public ArticleTagPair(Long articleId, TagV tag) {
+            this.articleId = articleId;
+            this.tag = tag;
+        }
+        
+        public Long getArticleId() {
+            return articleId;
+        }
+        
+        public TagV getTag() {
+            return tag;
+        }
+    }
+}

--- a/TARGET/src/main/resources/application.properties
+++ b/TARGET/src/main/resources/application.properties
@@ -1,0 +1,18 @@
+# Database Configuration
+spring.datasource.url=jdbc:postgresql://localhost:5432/realworld
+spring.datasource.username=postgres
+spring.datasource.password=postgres
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# JPA Configuration
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# Flyway Configuration
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+
+# Server Configuration
+server.port=8080

--- a/TARGET/src/main/resources/db/migration/V1__Create_initial_tables.sql
+++ b/TARGET/src/main/resources/db/migration/V1__Create_initial_tables.sql
@@ -1,0 +1,68 @@
+CREATE TABLE users (
+  id SERIAL PRIMARY KEY,
+  username VARCHAR(255) NOT NULL,
+  password VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  bio VARCHAR(1024),
+  image VARCHAR(255),
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  CONSTRAINT user_email_unique UNIQUE (email),
+  CONSTRAINT user_username_unique UNIQUE (username)
+);
+
+CREATE TABLE followers (
+  user_id INTEGER NOT NULL,
+  followee_id INTEGER NOT NULL,
+  inserted_at TIMESTAMP NOT NULL,
+  FOREIGN KEY (followee_id) REFERENCES users(id),
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  CONSTRAINT follower_follower_follwed_unq UNIQUE (user_id, followee_id)
+);
+
+CREATE TABLE articles (
+  id SERIAL PRIMARY KEY,
+  slug VARCHAR(255) NOT NULL,
+  title VARCHAR(300) NOT NULL,
+  description VARCHAR(255) NOT NULL,
+  body TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  author_id INTEGER NOT NULL,
+  FOREIGN KEY (author_id) REFERENCES users(id),
+  CONSTRAINT articles_slug_unique UNIQUE(slug)
+);
+
+CREATE TABLE tags (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  CONSTRAINT tag_name_unique UNIQUE(name)
+);
+
+CREATE TABLE articles_tags (
+  id SERIAL PRIMARY KEY,
+  article_id INTEGER NOT NULL,
+  tag_id INTEGER NOT NULL,
+  FOREIGN KEY (article_id) REFERENCES articles(id),
+  FOREIGN KEY (tag_id) REFERENCES tags(id),
+  CONSTRAINT article_tag_id_unique UNIQUE(article_id, tag_id)
+);
+
+CREATE TABLE comments (
+  id SERIAL PRIMARY KEY,
+  body VARCHAR (4096) NOT NULL,
+  article_id INTEGER NOT NULL,
+  author_id INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP NOT NULL,
+  FOREIGN KEY (article_id) REFERENCES articles(id),
+  FOREIGN KEY (author_id) REFERENCES users(id)
+);
+
+CREATE TABLE favorite (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL,
+  favorited_id INTEGER NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id),
+  FOREIGN KEY (favorited_id) REFERENCES articles(id)
+)

--- a/TARGET/src/test/java/realworld/com/tags/JdbcTagStorageTest.java
+++ b/TARGET/src/test/java/realworld/com/tags/JdbcTagStorageTest.java
@@ -1,0 +1,90 @@
+package realworld.com.tags;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import realworld.com.articles.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+class JdbcTagStorageTest {
+
+    @Mock
+    private TagRepository tagRepository;
+
+    @Mock
+    private ArticleTagRepository articleTagRepository;
+
+    private JdbcTagStorage tagStorage;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        tagStorage = new JdbcTagStorage(tagRepository, articleTagRepository);
+    }
+
+    @Test
+    void getTags_shouldReturnAllTags() {
+        // Arrange
+        List<TagEntity> tagEntities = Arrays.asList(
+                new TagEntity(1L, "one"),
+                new TagEntity(2L, "two")
+        );
+        when(tagRepository.findAll()).thenReturn(tagEntities);
+
+        // Act
+        CompletableFuture<List<TagV>> result = tagStorage.getTags();
+
+        // Assert
+        List<TagV> tags = result.join();
+        assertEquals(2, tags.size());
+        assertEquals("one", tags.get(0).getName());
+        assertEquals("two", tags.get(1).getName());
+    }
+
+    @Test
+    void findTagByNames_shouldReturnMatchingTags() {
+        // Arrange
+        List<String> tagNames = Arrays.asList("test");
+        List<TagEntity> tagEntities = Arrays.asList(
+                new TagEntity(1L, "test")
+        );
+        when(tagRepository.findByNameIn(tagNames)).thenReturn(tagEntities);
+
+        // Act
+        CompletableFuture<List<TagV>> result = tagStorage.findTagByNames(tagNames);
+
+        // Assert
+        List<TagV> tags = result.join();
+        assertEquals(1, tags.size());
+        assertEquals("test", tags.get(0).getName());
+    }
+
+    @Test
+    void insertAndGet_shouldReturnInsertedTags() {
+        // Arrange
+        List<TagV> tagsToInsert = Arrays.asList(
+                new TagV(-1L, "test")
+        );
+        List<TagEntity> savedEntities = Arrays.asList(
+                new TagEntity(1L, "test")
+        );
+        when(tagRepository.saveAll(any())).thenReturn(savedEntities);
+
+        // Act
+        CompletableFuture<List<TagV>> result = tagStorage.insertAndGet(tagsToInsert);
+
+        // Assert
+        List<TagV> tags = result.join();
+        assertEquals(1, tags.size());
+        assertEquals(1L, tags.get(0).getId());
+        assertEquals("test", tags.get(0).getName());
+    }
+}

--- a/TARGET/src/test/java/realworld/com/tags/TagControllerTest.java
+++ b/TARGET/src/test/java/realworld/com/tags/TagControllerTest.java
@@ -1,0 +1,49 @@
+package realworld.com.tags;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import realworld.com.articles.TagV;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class TagControllerTest {
+
+    @Mock
+    private TagService tagService;
+
+    private TagController tagController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        tagController = new TagController(tagService);
+    }
+
+    @Test
+    void getTags_shouldReturnTagsResponse() {
+        // Arrange
+        List<TagV> tags = Arrays.asList(
+                new TagV(1L, "one"),
+                new TagV(2L, "two")
+        );
+        ResponseTags responseTags = new ResponseTags(tags);
+        when(tagService.getTags()).thenReturn(CompletableFuture.completedFuture(responseTags));
+
+        // Act
+        CompletableFuture<ResponseEntity<ResponseTags>> result = tagController.getTags();
+
+        // Assert
+        ResponseEntity<ResponseTags> response = result.join();
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(responseTags, response.getBody());
+    }
+}

--- a/TARGET/src/test/java/realworld/com/tags/TagServiceTest.java
+++ b/TARGET/src/test/java/realworld/com/tags/TagServiceTest.java
@@ -1,0 +1,45 @@
+package realworld.com.tags;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import realworld.com.articles.TagV;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class TagServiceTest {
+
+    @Mock
+    private TagStorage tagStorage;
+
+    private TagService tagService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        tagService = new TagService(tagStorage);
+    }
+
+    @Test
+    void getTags_shouldReturnTags() {
+        // Arrange
+        List<TagV> expectedTags = Arrays.asList(
+                new TagV(1L, "one"),
+                new TagV(2L, "two")
+        );
+        when(tagStorage.getTags()).thenReturn(CompletableFuture.completedFuture(expectedTags));
+
+        // Act
+        CompletableFuture<ResponseTags> result = tagService.getTags();
+
+        // Assert
+        ResponseTags responseTags = result.join();
+        assertEquals(expectedTags, responseTags.getTags());
+    }
+}


### PR DESCRIPTION
This PR implements JIRA ticket STJM-3 to migrate the Tags module from Scala to Java 17 using Spring Boot framework.

## Changes
- Created Java equivalents of all Scala model classes in the tags module:
  - TagV.java
  - ArticleTag.java
  - ResponseTags.java
- Implemented JPA entities and repositories to replace Slick queries:
  - TagEntity.java + TagRepository.java
  - ArticleTagEntity.java + ArticleTagRepository.java
- Created Spring Data repositories for database operations
- Implemented service layer using CompletableFuture for asynchronous operations:
  - TagStorage.java (interface) + JdbcTagStorage.java (implementation)
  - TagService.java
- Created REST controller using Spring MVC to replace Akka HTTP routes:
  - TagController.java
- Added unit tests for all components
- Set up Maven build configuration

All migrated code is placed in the TARGET directory with the same package structure as the original code.
CompletableFuture is used instead of Scala Future for asynchronous operations.
The API response format is preserved for backward compatibility.